### PR TITLE
[Feat] Common 모듈 기본 구조 및 공통 유틸리티 구현

### DIFF
--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -8,14 +8,17 @@ bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
-	// 1. Web (GlobalExceptionHandler 등을 위해 필요)
+	// Web (GlobalExceptionHandler 등을 위해 필요)
 	api 'org.springframework.boot:spring-boot-starter-web'
 	api 'org.springframework.boot:spring-boot-starter-validation'
 
-	// 2. JSON 처리 (ObjectMapper 등)
+	// JSON 처리 (ObjectMapper 등)
 	api 'com.fasterxml.jackson.core:jackson-databind'
 
-	// 2. Swagger (OpenAPI)
+	// Swagger (OpenAPI)
 	api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	api 'org.webjars:swagger-ui:5.31.0'
+
+	// jpa
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -21,4 +21,13 @@ dependencies {
 
 	// jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// jwt
+	api 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/common-module/src/main/java/com/comatching/common/config/JpaAuditConfig.java
+++ b/common-module/src/main/java/com/comatching/common/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package com.comatching.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+}

--- a/common-module/src/main/java/com/comatching/common/config/SwaggerConfig.java
+++ b/common-module/src/main/java/com/comatching/common/config/SwaggerConfig.java
@@ -1,12 +1,13 @@
 package com.comatching.common.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {

--- a/common-module/src/main/java/com/comatching/common/dto/response/ApiResponse.java
+++ b/common-module/src/main/java/com/comatching/common/dto/response/ApiResponse.java
@@ -1,0 +1,62 @@
+package com.comatching.common.dto.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.comatching.common.exception.code.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+	private static final String SUCCESS_CODE = "GEN-000";
+	private static final String SUCCESS_MESSAGE = "요청이 성공적으로 처리되었습니다.";
+
+	private String code;
+	private int status;
+	private String message;
+	private T data;
+
+	public static <T> ApiResponse<T> ok() {
+		return ApiResponse.<T>builder()
+			.code(SUCCESS_CODE)
+			.status(HttpStatus.OK.value())
+			.message(SUCCESS_MESSAGE)
+			.build();
+	}
+
+	public static <T> ApiResponse<T> ok(T data) {
+		return ApiResponse.<T>builder()
+			.code(SUCCESS_CODE)
+			.status(HttpStatus.OK.value())
+			.message(SUCCESS_MESSAGE)
+			.data(data)
+			.build();
+	}
+
+	public static <T> ApiResponse<T> errorResponse(ErrorCode errorCode) {
+		return ApiResponse.<T>builder()
+			.code(errorCode.getCode())
+			.status(errorCode.getHttpStatus().value())
+			.message(errorCode.getMessage())
+			.build();
+	}
+
+	public static <T> ApiResponse<T> errorResponse(ErrorCode errorCode, T data) {
+		return ApiResponse.<T>builder()
+			.code(errorCode.getCode())
+			.status(errorCode.getHttpStatus().value())
+			.message(errorCode.getMessage())
+			.data(data)
+			.build();
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/dto/response/ApiResponse.java
+++ b/common-module/src/main/java/com/comatching/common/dto/response/ApiResponse.java
@@ -1,7 +1,6 @@
 package com.comatching.common.dto.response;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import com.comatching.common.exception.code.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/common-module/src/main/java/com/comatching/common/entity/BaseEntity.java
+++ b/common-module/src/main/java/com/comatching/common/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.comatching.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@Column(updatable = false, name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/common-module/src/main/java/com/comatching/common/exception/BusinessException.java
+++ b/common-module/src/main/java/com/comatching/common/exception/BusinessException.java
@@ -1,0 +1,36 @@
+package com.comatching.common.exception;
+
+import com.comatching.common.exception.code.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final Object errorData;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.errorData = null;
+	}
+
+	public BusinessException(ErrorCode errorCode, Object errorData) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+		this.errorData = errorData;
+	}
+
+	public BusinessException(ErrorCode errorCode, String customMessage) {
+		super(customMessage);
+		this.errorCode = errorCode;
+		this.errorData = null;
+	}
+
+	public BusinessException(ErrorCode errorCode, Object errorData, String customMessage) {
+		super(customMessage);
+		this.errorCode = errorCode;
+		this.errorData = errorData;
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/exception/code/ErrorCode.java
+++ b/common-module/src/main/java/com/comatching/common/exception/code/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.comatching.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+	String getCode();
+
+	HttpStatus getHttpStatus();
+
+	String getMessage();
+}

--- a/common-module/src/main/java/com/comatching/common/exception/code/GeneralErrorCode.java
+++ b/common-module/src/main/java/com/comatching/common/exception/code/GeneralErrorCode.java
@@ -1,6 +1,7 @@
 package com.comatching.common.exception.code;
 
 import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 
 @Getter

--- a/common-module/src/main/java/com/comatching/common/exception/code/GeneralErrorCode.java
+++ b/common-module/src/main/java/com/comatching/common/exception/code/GeneralErrorCode.java
@@ -1,0 +1,46 @@
+package com.comatching.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+import lombok.Getter;
+
+@Getter
+public enum GeneralErrorCode implements ErrorCode {
+
+	// 400 Bad Request
+	BAD_REQUEST("GEN-001", HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+	INVALID_INPUT_VALUE("GEN-002", HttpStatus.BAD_REQUEST, "올바르지 않은 입력값입니다."),
+	VALIDATION_FAILED("GEN-003", HttpStatus.BAD_REQUEST, "유효성 검사에 실패했습니다."),
+	MISSING_REQUEST_PARAMETER("GEN-004", HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다."),
+	TYPE_MISMATCH("GEN-005", HttpStatus.BAD_REQUEST, "파라미터 타입이 일치하지 않습니다."),
+	JSON_PARSE_ERROR("GEN-006", HttpStatus.BAD_REQUEST, "JSON 파싱에 실패했습니다."),
+	FILE_EXPIRED("GEN-103", HttpStatus.BAD_REQUEST, "파일의 유효기간이 만료되었습니다."),
+
+	// 404 Not Found
+	NOT_FOUND("GEN-007", HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+
+	// 405 Method Not Allowed
+	METHOD_NOT_ALLOWED("GEN-008", HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+
+	// 415 Unsupported Media Type
+	UNSUPPORTED_MEDIA_TYPE("GEN-009", HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 미디어 타입입니다."),
+
+	// 401 Unauthorized / 403 Forbidden
+	UNAUTHORIZED("GEN-010", HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+	FORBIDDEN("GEN-011", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+	// 500 Internal Server Error
+	INTERNAL_SERVER_ERROR("GEN-099", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+	DATABASE_ERROR("GEN-100", HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 오류가 발생했습니다."),
+	IO_ERROR("GEN-101", HttpStatus.INTERNAL_SERVER_ERROR, "입출력 오류가 발생했습니다."),
+	REDIS_CONNECTION_ERROR("GEN-102", HttpStatus.INTERNAL_SERVER_ERROR, "레디스 연결에 실패했습니다.");
+
+	private final String code;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	GeneralErrorCode(String code, HttpStatus httpStatus, String message) {
+		this.code = code;
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/exception/handler/GlobalExceptionHandler.java
+++ b/common-module/src/main/java/com/comatching/common/exception/handler/GlobalExceptionHandler.java
@@ -44,7 +44,8 @@ public class GlobalExceptionHandler {
 	 * @Valid 유효성 검사 실패 (400)
 	 */
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+	public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(
+		MethodArgumentNotValidException e) {
 		log.warn("[Validation Exception] {}", e.getMessage());
 
 		BindingResult bindingResult = e.getBindingResult();

--- a/common-module/src/main/java/com/comatching/common/exception/handler/GlobalExceptionHandler.java
+++ b/common-module/src/main/java/com/comatching/common/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,98 @@
+package com.comatching.common.exception.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import com.comatching.common.dto.response.ApiResponse;
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * BusinessException 처리
+	 */
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ApiResponse<Object>> handleBusinessException(BusinessException e) {
+		log.warn("[Business Exception] Code: {}, Message: {}", e.getErrorCode().getCode(), e.getMessage());
+
+		if (e.getErrorData() != null) {
+			return ResponseEntity
+				.status(e.getErrorCode().getHttpStatus())
+				.body(ApiResponse.errorResponse(e.getErrorCode(), e.getErrorData()));
+		}
+
+		return ResponseEntity
+			.status(e.getErrorCode().getHttpStatus())
+			.body(ApiResponse.errorResponse(e.getErrorCode()));
+	}
+
+	/**
+	 * @Valid 유효성 검사 실패 (400)
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+		log.warn("[Validation Exception] {}", e.getMessage());
+
+		BindingResult bindingResult = e.getBindingResult();
+		Map<String, String> errors = new HashMap<>();
+
+		// 실패한 필드와 메시지를 맵에 담음 (예: "email": "이메일 형식이 아닙니다")
+		for (FieldError fieldError : bindingResult.getFieldErrors()) {
+			errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+		}
+
+		return ResponseEntity
+			.status(GeneralErrorCode.VALIDATION_FAILED.getHttpStatus())
+			.body(ApiResponse.errorResponse(GeneralErrorCode.VALIDATION_FAILED, errors));
+	}
+
+	/**
+	 * JSON 파싱 실패 (400)
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ApiResponse<Void>> handleJsonException(HttpMessageNotReadableException e) {
+		log.warn("[JSON Parse Exception] {}", e.getMessage());
+
+		return ResponseEntity
+			.status(GeneralErrorCode.JSON_PARSE_ERROR.getHttpStatus())
+			.body(ApiResponse.errorResponse(GeneralErrorCode.JSON_PARSE_ERROR));
+	}
+
+	/**
+	 * URL 파라미터 타입 불일치 (400)
+	 */
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ApiResponse<Void>> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+		log.warn("[Type Mismatch Exception] Field: {}, Value: {}", e.getName(), e.getValue());
+
+		return ResponseEntity
+			.status(GeneralErrorCode.TYPE_MISMATCH.getHttpStatus())
+			.body(ApiResponse.errorResponse(GeneralErrorCode.TYPE_MISMATCH));
+	}
+
+	/**
+	 * [5] 나머지 모든 예외 (500)
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+		log.error("[Unhandled Exception] ", e);
+
+		return ResponseEntity
+			.status(GeneralErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+			.body(ApiResponse.errorResponse(GeneralErrorCode.INTERNAL_SERVER_ERROR));
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/util/CookieUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/CookieUtil.java
@@ -1,0 +1,41 @@
+package com.comatching.common.util;
+
+import java.time.Duration;
+
+import org.springframework.http.ResponseCookie;
+
+public class CookieUtil {
+
+	private CookieUtil() {}
+
+	// Access Token 쿠키
+	public static ResponseCookie createAccessTokenCookie(String accessToken) {
+		return ResponseCookie.from("accessToken", accessToken)
+			.path("/")
+			.httpOnly(true)
+			.secure(false) // HTTPS 환경에서는 true
+			.maxAge(Duration.ofDays(1).toSeconds())
+			.sameSite("Lax")
+			.build();
+	}
+
+	// Refresh Token 쿠키
+	public static ResponseCookie createRefreshTokenCookie(String refreshToken) {
+		return ResponseCookie.from("refreshToken", refreshToken)
+			.path("/auth/reissue")
+			.httpOnly(true)
+			.secure(false) // HTTPS 환경에서는 true
+			.maxAge(Duration.ofDays(7).toSeconds())
+			.sameSite("Lax")
+			.build();
+	}
+
+	// 로그아웃 시 쿠키 삭제
+	public static ResponseCookie createExpiredCookie(String cookieName) {
+		return ResponseCookie.from(cookieName, "")
+			.path("/")
+			.httpOnly(true)
+			.maxAge(0) // 즉시 만료
+			.build();
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/util/CookieUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/CookieUtil.java
@@ -6,7 +6,8 @@ import org.springframework.http.ResponseCookie;
 
 public class CookieUtil {
 
-	private CookieUtil() {}
+	private CookieUtil() {
+	}
 
 	// Access Token 쿠키
 	public static ResponseCookie createAccessTokenCookie(String accessToken) {
@@ -15,7 +16,7 @@ public class CookieUtil {
 			.httpOnly(true)
 			.secure(false) // HTTPS 환경에서는 true
 			.maxAge(Duration.ofDays(1).toSeconds())
-			.sameSite("Lax")
+			.sameSite("Strict")
 			.build();
 	}
 
@@ -26,7 +27,7 @@ public class CookieUtil {
 			.httpOnly(true)
 			.secure(false) // HTTPS 환경에서는 true
 			.maxAge(Duration.ofDays(7).toSeconds())
-			.sameSite("Lax")
+			.sameSite("Strict")
 			.build();
 	}
 

--- a/common-module/src/main/java/com/comatching/common/util/DateUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/DateUtil.java
@@ -8,11 +8,13 @@ public class DateUtil {
 	private static final String DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss";
 	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DEFAULT_PATTERN);
 
-	private DateUtil() {}
+	private DateUtil() {
+	}
 
 	// LocalDateTime -> String
 	public static String toString(LocalDateTime date) {
-		if (date == null) return "";
+		if (date == null)
+			return "";
 		return date.format(formatter);
 	}
 

--- a/common-module/src/main/java/com/comatching/common/util/DateUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/DateUtil.java
@@ -1,0 +1,28 @@
+package com.comatching.common.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+
+	private static final String DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss";
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DEFAULT_PATTERN);
+
+	private DateUtil() {}
+
+	// LocalDateTime -> String
+	public static String toString(LocalDateTime date) {
+		if (date == null) return "";
+		return date.format(formatter);
+	}
+
+	// String -> LocalDateTime
+	public static LocalDateTime toLocalDateTime(String dateStr) {
+		return LocalDateTime.parse(dateStr, formatter);
+	}
+
+	// 현재 시간을 문자열로
+	public static String nowString() {
+		return LocalDateTime.now().format(formatter);
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/util/JsonUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/JsonUtil.java
@@ -11,7 +11,8 @@ public class JsonUtil {
 	private static final ObjectMapper objectMapper = new ObjectMapper()
 		.registerModule(new JavaTimeModule());
 
-	private JsonUtil() {}
+	private JsonUtil() {
+	}
 
 	// 객체 -> JSON String
 	public static String toJson(Object object) {

--- a/common-module/src/main/java/com/comatching/common/util/JsonUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/JsonUtil.java
@@ -1,0 +1,33 @@
+package com.comatching.common.util;
+
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class JsonUtil {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper()
+		.registerModule(new JavaTimeModule());
+
+	private JsonUtil() {}
+
+	// 객체 -> JSON String
+	public static String toJson(Object object) {
+		try {
+			return objectMapper.writeValueAsString(object);
+		} catch (JsonProcessingException e) {
+			throw new BusinessException(GeneralErrorCode.JSON_PARSE_ERROR);
+		}
+	}
+
+	// JSON String -> 객체
+	public static <T> T fromJson(String json, Class<T> clazz) {
+		try {
+			return objectMapper.readValue(json, clazz);
+		} catch (JsonProcessingException e) {
+			throw new BusinessException(GeneralErrorCode.JSON_PARSE_ERROR);
+		}
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/util/JwtUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/JwtUtil.java
@@ -1,0 +1,86 @@
+package com.comatching.common.util;
+
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+	private final Key key;
+	private final long accessTokenValidity;
+	private final long refreshTokenValidity;
+
+	public JwtUtil(
+		@Value("${jwt.secret}") String secret,
+		@Value("${jwt.access-token.expiration}") long accessTokenValidity,
+		@Value("${jwt.refresh-token.expiration}") long refreshTokenValidity) {
+		this.key = Keys.hmacShaKeyFor(secret.getBytes());
+		this.accessTokenValidity = accessTokenValidity;
+		this.refreshTokenValidity = refreshTokenValidity;
+	}
+
+	// Access Token 생성
+	public String createAccessToken(Long memberId, String email, String role) {
+		return createToken(memberId, email, role, accessTokenValidity);
+	}
+
+	// Refresh Token 생성
+	public String createRefreshToken(Long memberId) {
+		return createToken(memberId, null, null, refreshTokenValidity);
+	}
+
+	// 내부 토큰 생성 로직
+	private String createToken(Long memberId, String email, String role, long validity) {
+		Date now = new Date();
+		Date expiration = new Date(now.getTime() + validity);
+
+		var builder = Jwts.builder()
+			.setSubject(String.valueOf(memberId))
+			.setIssuedAt(now)
+			.setExpiration(expiration)
+			.signWith(key, SignatureAlgorithm.HS256);
+
+		if (email != null) builder.claim("email", email);
+		if (role != null) builder.claim("role", role);
+
+		return builder.compact();
+	}
+
+	// 토큰 파싱 (Claims 반환)
+	public Claims parseToken(String token) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			throw new BusinessException(GeneralErrorCode.UNAUTHORIZED, "토큰이 만료되었습니다.");
+		} catch (Exception e) {
+			throw new BusinessException(GeneralErrorCode.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+		}
+	}
+
+	// 토큰 만료 여부 등 유효성 검증 (Gateway용)
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		} catch (Exception e) {
+			log.warn("Invalid JWT Token: {}", e.getMessage());
+			return false;
+		}
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/util/JwtUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/JwtUtil.java
@@ -1,18 +1,20 @@
 package com.comatching.common.util;
 
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import com.comatching.common.exception.BusinessException;
 import com.comatching.common.exception.code.GeneralErrorCode;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-import java.security.Key;
-import java.util.Date;
 
 @Slf4j
 @Component
@@ -52,8 +54,10 @@ public class JwtUtil {
 			.setExpiration(expiration)
 			.signWith(key, SignatureAlgorithm.HS256);
 
-		if (email != null) builder.claim("email", email);
-		if (role != null) builder.claim("role", role);
+		if (email != null)
+			builder.claim("email", email);
+		if (role != null)
+			builder.claim("role", role);
 
 		return builder.compact();
 	}

--- a/common-module/src/main/java/com/comatching/common/util/SecurityUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/SecurityUtil.java
@@ -1,0 +1,47 @@
+package com.comatching.common.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+public class SecurityUtil {
+
+	private SecurityUtil() {}
+
+	/**
+	 * 현재 로그인한 사용자의 ID(PK)
+	 * 로그인하지 않은 상태라면 예외
+	 */
+	public static Long getCurrentMemberId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		// 1. 인증 정보가 아예 없는 경우
+		if (authentication == null || authentication.getName() == null) {
+			throw new BusinessException(GeneralErrorCode.UNAUTHORIZED, "인증 정보가 존재하지 않습니다.");
+		}
+
+		// 2. 익명 사용자 (로그인 안 함)
+		if (authentication.getPrincipal().equals("anonymousUser")) {
+			throw new BusinessException(GeneralErrorCode.UNAUTHORIZED, "로그인이 필요한 서비스입니다.");
+		}
+
+		// 3. ID 파싱 (Gateway가 헤더에 "1", "2" 처럼 ID를 넣어줬다고 가정)
+		try {
+			return Long.parseLong(authentication.getName());
+		} catch (NumberFormatException e) {
+			throw new BusinessException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "인증 ID 형식이 올바르지 않습니다.");
+		}
+	}
+
+	/**
+	 * 로그인 여부만 확인
+	 */
+	public static boolean isAuthenticated() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		return authentication != null
+			&& authentication.isAuthenticated()
+			&& !authentication.getPrincipal().equals("anonymousUser");
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/util/SecurityUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/SecurityUtil.java
@@ -8,7 +8,8 @@ import com.comatching.common.exception.code.GeneralErrorCode;
 
 public class SecurityUtil {
 
-	private SecurityUtil() {}
+	private SecurityUtil() {
+	}
 
 	/**
 	 * 현재 로그인한 사용자의 ID(PK)

--- a/common-module/src/test/java/com/comatching/common/util/CookieUtilTest.java
+++ b/common-module/src/test/java/com/comatching/common/util/CookieUtilTest.java
@@ -1,0 +1,56 @@
+package com.comatching.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+class CookieUtilTest {
+
+	@Test
+	void createAccessTokenCookie() {
+		// given
+		String token = "access-token-value";
+
+		// when
+		ResponseCookie cookie = CookieUtil.createAccessTokenCookie(token);
+
+		// then
+		assertThat(cookie.getValue()).isEqualTo(token);
+		assertThat(cookie.isHttpOnly()).isTrue();
+		assertThat(cookie.getPath()).isEqualTo("/");
+		assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(Duration.ofDays(1).toSeconds());
+		assertThat(cookie.getSameSite()).isEqualTo("Strict");
+	}
+
+	@Test
+	void createRefreshTokenCookie() {
+		// given
+		String token = "refresh-token-value";
+
+		// when
+		ResponseCookie cookie = CookieUtil.createRefreshTokenCookie(token);
+
+		// then
+		assertThat(cookie.getValue()).isEqualTo(token);
+		assertThat(cookie.isHttpOnly()).isTrue();
+		assertThat(cookie.getPath()).isEqualTo("/auth/reissue");
+		assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(Duration.ofDays(7).toSeconds());
+	}
+
+	@Test
+	void createExpiredCookie() {
+		// given
+		String cookieName = "accessToken";
+
+		// when
+		ResponseCookie cookie = CookieUtil.createExpiredCookie(cookieName);
+
+		// then
+		assertThat(cookie.getName()).isEqualTo(cookieName);
+		assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(0);
+		assertThat(cookie.getValue()).isEmpty();
+	}
+}

--- a/common-module/src/test/java/com/comatching/common/util/DateUtilTest.java
+++ b/common-module/src/test/java/com/comatching/common/util/DateUtilTest.java
@@ -1,0 +1,45 @@
+package com.comatching.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class DateUtilTest {
+
+	@Test
+	void toString_Success() {
+		// given
+		LocalDateTime dateTime = LocalDateTime.of(2026, 1, 1, 12, 30, 45);
+
+		// when
+		String result = DateUtil.toString(dateTime);
+
+		// then
+		assertThat(result).isEqualTo("2026-01-01 12:30:45");
+	}
+
+	@Test
+	void toString_Null() {
+		// when
+		String result = DateUtil.toString(null);
+
+		// then
+		assertThat(result).isEqualTo("");
+	}
+
+	@Test
+	void toLocalDateTime_Success() {
+		// given
+		String dateStr = "2026-12-25 10:00:00";
+
+		// when
+		LocalDateTime result = DateUtil.toLocalDateTime(dateStr);
+
+		// then
+		assertThat(result.getYear()).isEqualTo(2026);
+		assertThat(result.getMonthValue()).isEqualTo(12);
+		assertThat(result.getDayOfMonth()).isEqualTo(25);
+	}
+}

--- a/common-module/src/test/java/com/comatching/common/util/JsonUtilTest.java
+++ b/common-module/src/test/java/com/comatching/common/util/JsonUtilTest.java
@@ -1,0 +1,67 @@
+package com.comatching.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+class JsonUtilTest {
+
+	@Test
+	void toJson_Success() {
+		// given
+		TestDto dto = new TestDto("test", 20, LocalDateTime.now());
+
+		// when
+		String json = JsonUtil.toJson(dto);
+
+		// then
+		assertThat(json).contains("test");
+		assertThat(json).contains("\"age\":20");
+	}
+
+	@Test
+	void fromJson_Success() {
+		// given
+		String json = "{\"name\":\"test\",\"age\":20}";
+
+		// when
+		TestDto result = JsonUtil.fromJson(json, TestDto.class);
+
+		// then
+		assertThat(result.name).isEqualTo("test");
+		assertThat(result.age).isEqualTo(20);
+	}
+
+	@Test
+	void fromJson_Fail() {
+		// given
+		String invalidJson = "{name:test, age:20";
+
+		// when & then
+		assertThatThrownBy(() -> JsonUtil.fromJson(invalidJson, TestDto.class))
+			.isInstanceOf(BusinessException.class)
+			.extracting(ex -> ((BusinessException)ex).getErrorCode())
+			.isEqualTo(GeneralErrorCode.JSON_PARSE_ERROR);
+	}
+
+	static class TestDto {
+		public String name;
+		public int age;
+		public LocalDateTime createdAt;
+
+		public TestDto() {
+		}
+
+		public TestDto(String name, int age, LocalDateTime createdAt) {
+			this.name = name;
+			this.age = age;
+			this.createdAt = createdAt;
+		}
+	}
+
+}

--- a/common-module/src/test/java/com/comatching/common/util/JwtUtilTest.java
+++ b/common-module/src/test/java/com/comatching/common/util/JwtUtilTest.java
@@ -1,0 +1,51 @@
+package com.comatching.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.jsonwebtoken.Claims;
+
+class JwtUtilTest {
+
+	private static final String SECRET_KEY = "c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK";
+	private final JwtUtil jwtUtil = new JwtUtil(SECRET_KEY, 3600000L, 3600000L);
+
+	Long memberId;
+	String email;
+	String role;
+
+	@BeforeEach
+	void setUp() {
+		memberId = 1L;
+		email = "test@test.com";
+		role = "ROLE_USER";
+	}
+
+	@Test
+	void createAndParseToken() {
+		//when
+		String token = jwtUtil.createAccessToken(memberId, email, role);
+		Claims claims = jwtUtil.parseToken(token);
+
+		//then
+		assertThat(token).isNotNull();
+		assertThat(claims.getSubject()).isEqualTo("1");
+		assertThat(claims.get("email")).isEqualTo("test@test.com");
+	}
+
+	@Test
+	void validateToken() {
+		//given
+		String token = jwtUtil.createAccessToken(memberId, email, role);
+
+		//when
+		boolean isValid = jwtUtil.validateToken(token);
+
+		//then
+		assertThat(isValid).isTrue();
+
+	}
+
+}

--- a/common-module/src/test/java/com/comatching/common/util/SecurityUtilTest.java
+++ b/common-module/src/test/java/com/comatching/common/util/SecurityUtilTest.java
@@ -1,0 +1,43 @@
+package com.comatching.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+class SecurityUtilTest {
+
+	@AfterEach
+	void clear() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void getCurrentMemberId_Success() {
+		//given
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		context.setAuthentication(new UsernamePasswordAuthenticationToken("100", null));
+		SecurityContextHolder.setContext(context);
+
+		//when
+		Long memberId = SecurityUtil.getCurrentMemberId();
+
+		//then
+		assertThat(memberId).isEqualTo(100L);
+	}
+
+	@Test
+	void getCurrentMemberId_Fail() {
+		assertThatThrownBy(SecurityUtil::getCurrentMemberId)
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining("인증 정보가 존재하지 않습니다")
+			.extracting(ex -> ((BusinessException)ex).getErrorCode())
+			.isEqualTo(GeneralErrorCode.UNAUTHORIZED);
+	}
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
   application:
     name: gateway-service
 
+  config:
+    import: optional:classpath:application-secret.yml
+
   cloud:
     gateway:
       server:


### PR DESCRIPTION
# [Feat] Common 모듈 기본 구조 및 공통 유틸리티 구현

## 🔗 Related Issue
- Closes #1

## 📋 Summary
MSA 서비스 전반에서 사용될 **Common 모듈의 초기 아키텍처를 구축**
표준 응답 포맷, 전역 예외 처리, 보안/인증 유틸리티, 그리고 JPA 공통 설정 등을 포함하여 향후 개발될 서비스(`auth`, `member` 등)의 기반을 마련

## 🛠 Key Changes

### 1. 프로젝트 구조 및 의존성 관리
- **패키지 구조화**: `config`, `dto`, `entity`, `exception`, `util` 등 계층별 패키지 정의
- **Gradle 설정**:
  - `spring-boot-starter-data-jpa` (implementation)
  - `jjwt` (JWT 라이브러리), `jackson`, `spring-security-core` 의존성 추가

### 2. 표준 응답 및 예외 처리 (Response & Exception)
- **`ApiResponse`**: 성공(`ok`) 및 실패(`error`) 시 일관된 JSON 응답을 위한 Wrapper 클래스 구현 (Builder 패턴 적용)
- **`GlobalExceptionHandler`**: `@RestControllerAdvice`를 통해 비즈니스 예외 및 Validation 예외를 전역적으로 핸들링
- **`BusinessException` & `ErrorCode`**: 커스텀 예외 처리 및 에러 코드 Enum 관리 (한글 메시지 적용)

### 3. 보안 및 유틸리티 (Security & Utils)
- **`JwtUtil`**:
  - Access Token 및 Refresh Token 발급 로직 구현
  - `application.yml` 설정을 통한 유연한 Secret Key 관리 지원
- **`CookieUtil`**:
  - XSS 방지를 위한 `HttpOnly`, CSRF 방지를 위한 `SameSite=Strict` 설정 적용
  - Refresh Token 쿠키의 Path를 `/auth/reissue`로 제한하여 보안 강화
- **`SecurityUtil`**: `SecurityContextHolder`에서 현재 인증된 사용자 ID(`currentMemberId`)를 안전하게 추출
- **`JsonUtil` & `DateUtil`**: `ObjectMapper` 래핑 및 `LocalDateTime` 포맷 통일

### 4. JPA 공통 설정
- **`BaseEntity`**: `createdAt`, `updatedAt` 자동 관리를 위한 MappedSuperclass 구현 및 Auditing 활성화

### 5. 테스트 코드 (Tests)
- 핵심 유틸리티 클래스에 대한 단위 테스트 작성 및 통과 완료
  - ✅ `JwtUtilTest`: 토큰 생성, 파싱, 검증 로직 테스트
  - ✅ `CookieUtilTest`: 쿠키 속성(HttpOnly, Secure, MaxAge) 및 Path 설정 검증
  - ✅ `SecurityUtilTest`: 인증/미인증 상태에 따른 ID 추출 및 예외 발생 검증
  - ✅ `JsonUtilTest`, `DateUtilTest`: 변환 로직 및 예외 처리 검증

## ✅ Check List
- [x] 빌드가 에러 없이 정상적으로 수행되는가?
- [x] 모든 단위 테스트(`src/test/java`)가 통과하는가?
- [x] 불필요한 공백이나 주석은 제거되었는가?
- [x] 커밋 메시지 컨벤션을 준수하였는가?

## 🚀 Next Steps
**인증 서비스(Auth Service)** 개발 예정