### PR TITLE
[Feat] AWS S3 Presigned URL 유틸리티 구현

### DIFF
--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -30,4 +30,7 @@ dependencies {
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// aws s3
+	api 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2'
 }

--- a/common-module/src/main/java/com/comatching/common/config/S3Config.java
+++ b/common-module/src/main/java/com/comatching/common/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.comatching.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+	@Value("${spring.cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${spring.cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${spring.cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public S3Presigner s3Presigner() {
+		return S3Presigner.builder()
+			.region(Region.of(region))
+			.credentialsProvider(StaticCredentialsProvider.create(
+				AwsBasicCredentials.create(accessKey, secretKey)
+			))
+			.build();
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/dto/s3/S3UploadResponseDto.java
+++ b/common-module/src/main/java/com/comatching/common/dto/s3/S3UploadResponseDto.java
@@ -1,0 +1,10 @@
+package com.comatching.common.dto.s3;
+
+import lombok.Builder;
+
+@Builder
+public record S3UploadResponseDto(
+	String presignedUrl,
+	String imageKey
+) {
+}

--- a/common-module/src/main/java/com/comatching/common/service/S3Service.java
+++ b/common-module/src/main/java/com/comatching/common/service/S3Service.java
@@ -1,0 +1,94 @@
+package com.comatching.common.service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.comatching.common.dto.s3.S3UploadResponseDto;
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	private final S3Template s3Template;
+	private final S3Presigner s3Presigner;
+
+	@Value("${spring.cloud.aws.s3.bucket}")
+	private String bucketName;
+
+	/**
+	 * Presigned URL 발급 (파일 업로드용)
+	 *
+	 * @param dirName          S3 내 디렉토리 이름
+	 * @param originalFilename 클라이언트가 올릴 원본 파일명
+	 */
+	public S3UploadResponseDto getPresignedPutUrl(String dirName, String originalFilename) {
+		// 확장자 검증
+		String extension = validateImageExtension(originalFilename);
+
+		// 유니크한 파일명 생성
+		String imageKey = dirName + "/" + UUID.randomUUID() + "." + extension;
+
+		// Presigned URL 생성 요청 객체 생성
+		PutObjectRequest objectRequest = PutObjectRequest.builder()
+			.bucket(bucketName)
+			.key(imageKey)
+			.contentType("image/" + (extension.equals("jpg") ? "jpeg" : extension))
+			.build();
+
+		PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+			.signatureDuration(Duration.ofMinutes(5))
+			.putObjectRequest(objectRequest)
+			.build();
+
+		// URL 발급
+		String presignedUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
+
+		return S3UploadResponseDto.builder()
+			.presignedUrl(presignedUrl)
+			.imageKey(imageKey)
+			.build();
+	}
+
+	/**
+	 * S3 파일 삭제
+	 *
+	 * @param imageKey 삭제할 파일의 키 (예: profiles/abc.jpg)
+	 */
+	public void deleteFile(String imageKey) {
+		if (imageKey == null || imageKey.isBlank())
+			return;
+		try {
+			s3Template.deleteObject(bucketName, imageKey);
+		} catch (Exception e) {
+			log.error("S3 File Delete Error: {}", imageKey, e);
+			throw new BusinessException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "이미지 삭제 중 오류가 발생했습니다.");
+		}
+	}
+
+	private String validateImageExtension(String filename) {
+		int lastDotIndex = filename.lastIndexOf(".");
+		if (lastDotIndex == -1) {
+			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "파일 확장자가 없습니다.");
+		}
+
+		String extension = filename.substring(lastDotIndex + 1).toLowerCase();
+		if (!extension.equals("jpg") && !extension.equals("jpeg") &&
+			!extension.equals("png") && !extension.equals("gif")) {
+			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 이미지 형식입니다.");
+		}
+		return extension;
+	}
+}

--- a/common-module/src/test/java/com/comatching/common/service/S3ServiceTest.java
+++ b/common-module/src/test/java/com/comatching/common/service/S3ServiceTest.java
@@ -1,0 +1,116 @@
+package com.comatching.common.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.comatching.common.dto.s3.S3UploadResponseDto;
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+import io.awspring.cloud.s3.S3Template;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+	@Mock
+	private S3Template s3Template;
+
+	@Mock
+	private S3Presigner s3Presigner;
+
+	@InjectMocks
+	private S3Service s3Service;
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(s3Service, "bucketName", "test-bucket");
+	}
+
+	@Test
+	void getPresignedPutUrl_Success() throws MalformedURLException {
+		//given
+		String dirName = "profiles";
+		String filename = "test-image.jpg";
+		String expectedUrl = "https://s3.ap-northeast-2.amazonaws.com/test-bucket/profiles/uuid.jpg";
+
+		PresignedPutObjectRequest presignedRequest = mock(PresignedPutObjectRequest.class);
+		given(presignedRequest.url()).willReturn(new URL(expectedUrl));
+		given(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).willReturn(presignedRequest);
+
+		//when
+		S3UploadResponseDto response = s3Service.getPresignedPutUrl(dirName, filename);
+
+		//then
+		assertThat(response.presignedUrl()).isEqualTo(expectedUrl);
+		assertThat(response.imageKey()).startsWith("profiles/");
+		assertThat(response.imageKey()).endsWith(".jpg");
+		assertThat(response.imageKey().split("/")[1].length()).isGreaterThan(10);
+	}
+
+	@Test
+	void getPresignedPutUrl_Fail_NoExtension() {
+		// given
+		String filename = "image";
+
+		// when & then
+		assertThatThrownBy(() -> s3Service.getPresignedPutUrl("profiles", filename))
+			.isInstanceOf(BusinessException.class)
+			.extracting(ex -> ((BusinessException) ex).getErrorCode())
+			.isEqualTo(GeneralErrorCode.INVALID_INPUT_VALUE);
+	}
+
+	@Test
+	void getPresignedPutUrl_Fail_InvalidExtension() {
+		// given
+		String filename = "script.sh";
+
+		// when & then
+		assertThatThrownBy(() -> s3Service.getPresignedPutUrl("profiles", filename))
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining("지원하지 않는 이미지 형식")
+			.extracting(ex -> ((BusinessException) ex).getErrorCode())
+			.isEqualTo(GeneralErrorCode.INVALID_INPUT_VALUE);
+	}
+
+	@Test
+	void deleteFile_Success() {
+		// given
+		String imageKey = "profiles/abc-123.jpg";
+
+		// when
+		s3Service.deleteFile(imageKey);
+
+		// then
+		verify(s3Template, times(1)).deleteObject("test-bucket", imageKey);
+	}
+
+	@Test
+	void deleteFile_Fail_S3Error() {
+		// given
+		String imageKey = "profiles/error.jpg";
+		doThrow(new RuntimeException("AWS S3 Error")).when(s3Template).deleteObject(anyString(), anyString());
+
+		// when & then
+		assertThatThrownBy(() -> s3Service.deleteFile(imageKey))
+			.isInstanceOf(BusinessException.class)
+			.extracting(ex -> ((BusinessException) ex).getErrorCode())
+			.isEqualTo(GeneralErrorCode.INTERNAL_SERVER_ERROR);
+	}
+}


### PR DESCRIPTION
# [Feat] AWS S3 Presigned URL 유틸리티 구현

## 🔗 Related Issue
- Closes #3 
## 📋 Summary
MSA 환경의 Stateless 특성을 준수하고 서버 부하를 줄이기 위해, **AWS S3 Presigned URL(사전 서명된 URL)** 방식을 도입했습니다.
이제 클라이언트가 서버를 거치지 않고 S3에 직접 이미지를 업로드할 수 있으며, 서버는 업로드 권한만 발급합니다.

## 🛠 Key Changes

### 1. AWS S3 설정 및 의존성
- **Dependency**: `spring-cloud-aws-starter-s3` (3.x) 추가
- **Config**: `S3Config`에서 `S3Presigner` 빈 등록 (URL 발급용)

### 2. S3Service (Core Logic)
- **`getPresignedPutUrl(dirName, originalFilename)`**:
  - 파일명 중복 방지를 위한 UUID 적용
  - 보안을 위해 유효기간(5분) 설정
  - 확장자 검증 로직 포함
- **`deleteFile(imageKey)`**:
  - 파일 삭제 로직 구현 (S3Template 활용)

### 3. DTO
- **`S3UploadResponseDto`**: Presigned URL과 저장된 Image Key를 반환하는 객체 정의

### 4. Tests
- **`S3ServiceTest`**: Mockito를 활용하여 AWS 통신 없이 URL 발급 및 예외 처리 로직 검증 완료

## ✅ Check List
- [x] 빌드가 에러 없이 정상적으로 수행되는가?
- [x] 단위 테스트(`S3ServiceTest`)가 통과하는가?
- [x] AWS 설정(yml)이 올바르게 가이드 되었는가?