### PR TITLE
[Feat] 소셜 로그인 아키텍처 구현 (OAuth2/OIDC + Strategy Pattern)

### DIFF
--- a/auth-service/src/main/java/com/comatching/auth/domain/controller/AuthController.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/controller/AuthController.java
@@ -1,4 +1,4 @@
-package com.comatching.auth.global.security.refresh.controller;
+package com.comatching.auth.domain.controller;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.comatching.auth.domain.dto.TokenResponse;
-import com.comatching.auth.global.security.refresh.service.RefreshTokenService;
+import com.comatching.auth.domain.service.AuthService;
 import com.comatching.common.dto.response.ApiResponse;
 import com.comatching.common.util.CookieUtil;
 
@@ -18,9 +18,9 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-public class RefreshTokenController {
+public class AuthController {
 
-	private final RefreshTokenService refreshTokenService;
+	private final AuthService authService;
 
 	@PostMapping("/reissue")
 	public ResponseEntity<ApiResponse<Void>> reissue(
@@ -28,7 +28,7 @@ public class RefreshTokenController {
 		HttpServletResponse response
 	) {
 
-		TokenResponse tokenResponse = refreshTokenService.reissue(refreshToken);
+		TokenResponse tokenResponse = authService.reissue(refreshToken);
 
 		ResponseCookie accessCookie = CookieUtil.createAccessTokenCookie(tokenResponse.accessToken());
 		ResponseCookie refreshCookie = CookieUtil.createRefreshTokenCookie(tokenResponse.refreshToken());
@@ -44,7 +44,7 @@ public class RefreshTokenController {
 		@CookieValue(name = "refreshToken", required = false) String refreshToken,
 		HttpServletResponse response) {
 
-		refreshTokenService.logout(refreshToken);
+		authService.logout(refreshToken);
 
 		ResponseCookie accessCookie = CookieUtil.createExpiredCookie("accessToken");
 		ResponseCookie refreshCookie = CookieUtil.createExpiredCookie("refreshToken");

--- a/auth-service/src/main/java/com/comatching/auth/domain/service/AuthService.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/service/AuthService.java
@@ -1,4 +1,4 @@
-package com.comatching.auth.global.security.refresh.service;
+package com.comatching.auth.domain.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class RefreshTokenService {
+public class AuthService {
 
 	private final JwtUtil jwtUtil;
 	private final RefreshTokenRepository refreshTokenRepository;

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/factory/OAuth2UserInfoFactory.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/factory/OAuth2UserInfoFactory.java
@@ -1,0 +1,22 @@
+package com.comatching.auth.global.security.oauth2.factory;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.comatching.auth.global.security.oauth2.provider.kakao.KakaoUser;
+import com.comatching.auth.global.security.oauth2.user.OAuth2UserInfo;
+import com.comatching.common.domain.enums.SocialType;
+
+public class OAuth2UserInfoFactory {
+
+	public static OAuth2UserInfo getOAuth2UserInfo(OAuth2User oAuth2User, ClientRegistration clientRegistration) {
+
+		String registrationId = clientRegistration.getRegistrationId();
+		SocialType socialType = SocialType.from(registrationId);
+
+		return switch (socialType) {
+			case KAKAO -> new KakaoUser(oAuth2User, clientRegistration);
+			default -> throw new IllegalArgumentException("지원하지 않는 socialType: " + socialType);
+		};
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/handler/CustomOAuth2FailureHandler.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/handler/CustomOAuth2FailureHandler.java
@@ -1,0 +1,27 @@
+package com.comatching.auth.global.security.oauth2.handler;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomOAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	@Value("${client.url:http://localhost:3000}")
+	private String clientUrl;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException, ServletException {
+		super.onAuthenticationFailure(request, response, exception);
+
+		getRedirectStrategy().sendRedirect(request, response,clientUrl + "/oauth2/callback/failure");
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/handler/CustomOAuth2SuccessHandler.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/handler/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,61 @@
+package com.comatching.auth.global.security.oauth2.handler;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.comatching.auth.global.security.oauth2.user.CustomOAuth2User;
+import com.comatching.auth.global.security.refresh.RefreshToken;
+import com.comatching.auth.global.security.refresh.repository.RefreshTokenRepository;
+import com.comatching.common.util.CookieUtil;
+import com.comatching.common.util.JwtUtil;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+	private final JwtUtil jwtUtil;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	@Value("${client.url:http://localhost:3000}")
+	private String clientUrl;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+		Authentication authentication) throws IOException, ServletException {
+
+		// UserPrincipal(CustomOAuth2User) 추출
+		CustomOAuth2User userPrincipal = (CustomOAuth2User)authentication.getPrincipal();
+		Long memberId = userPrincipal.getId();
+		String role = userPrincipal.getAuthorities().iterator().next().getAuthority();
+
+		// 토큰 발급
+		String accessToken = jwtUtil.createAccessToken(memberId, userPrincipal.getEmail(), role, userPrincipal.getStatus());
+		String refreshToken = jwtUtil.createRefreshToken(memberId);
+
+		// Refresh Token Redis 저장
+		refreshTokenRepository.save(RefreshToken.builder()
+			.memberId(memberId)
+			.token(refreshToken)
+			.build());
+
+		// 쿠키 설정
+		ResponseCookie accessCookie = CookieUtil.createAccessTokenCookie(accessToken);
+		ResponseCookie refreshCookie = CookieUtil.createRefreshTokenCookie(refreshToken);
+
+		response.addHeader("Set-Cookie", accessCookie.toString());
+		response.addHeader("Set-Cookie", refreshCookie.toString());
+
+		getRedirectStrategy().sendRedirect(request, response, clientUrl + "/oauth2/callback/success");
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/provider/kakao/KakaoUser.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/provider/kakao/KakaoUser.java
@@ -1,0 +1,33 @@
+package com.comatching.auth.global.security.oauth2.provider.kakao;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.comatching.auth.global.security.oauth2.user.OAuth2ProviderUserInfo;
+
+public class KakaoUser extends OAuth2ProviderUserInfo {
+
+	public KakaoUser(OAuth2User oAuth2User, ClientRegistration clientRegistration) {
+		super(oAuth2User.getAttributes(), clientRegistration);
+	}
+
+	@Override
+	public String getProviderId() {
+		return (String)getAttributes().get("sub");
+	}
+
+	@Override
+	public String getProvider() {
+		return "KAKAO";
+	}
+
+	@Override
+	public String getEmail() {
+		return (String)getAttributes().get("email");
+	}
+
+	@Override
+	public String getNickname() {
+		return (String)getAttributes().get("nickname");
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,24 @@
+package com.comatching.auth.global.security.oauth2.service;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+	private final SocialLoginService socialLoginService;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+
+		return socialLoginService.processUser(userRequest.getClientRegistration(), oAuth2User);
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/service/CustomOidcUserService.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/service/CustomOidcUserService.java
@@ -1,0 +1,25 @@
+package com.comatching.auth.global.security.oauth2.service;
+
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService extends OidcUserService {
+
+	private final SocialLoginService socialLoginService;
+
+	@Override
+	public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+
+		OAuth2User oidcUser = super.loadUser(userRequest);
+
+		return socialLoginService.processUser(userRequest.getClientRegistration(), oidcUser);
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/service/SocialLoginService.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/service/SocialLoginService.java
@@ -1,0 +1,54 @@
+package com.comatching.auth.global.security.oauth2.service;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.comatching.auth.global.security.oauth2.factory.OAuth2UserInfoFactory;
+import com.comatching.auth.global.security.oauth2.user.CustomOAuth2User;
+import com.comatching.auth.global.security.oauth2.user.OAuth2UserInfo;
+import com.comatching.auth.infra.client.MemberServiceClient;
+import com.comatching.common.domain.enums.SocialType;
+import com.comatching.common.dto.auth.MemberLoginDto;
+import com.comatching.common.dto.auth.SocialLoginRequestDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SocialLoginService {
+
+	private final MemberServiceClient memberServiceClient;
+
+	public CustomOAuth2User processUser(ClientRegistration clientRegistration, OAuth2User oAuth2User) {
+
+		String registrationId = clientRegistration.getRegistrationId();
+
+		// Factory를 이용해 유저 정보 표준화
+		OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2User, clientRegistration);
+
+		// Member Service로 보낼 DTO 생성
+		SocialLoginRequestDto loginRequest = new SocialLoginRequestDto(
+			userInfo.getEmail(),
+			userInfo.getNickname(),
+			SocialType.from(registrationId),
+			userInfo.getProviderId()
+		);
+
+		// Member Service 호출
+		MemberLoginDto memberDto = memberServiceClient.socialLogin(loginRequest);
+
+		// CustomOAuth2User 반환
+		if (oAuth2User instanceof OidcUser oidcUser) {
+			return new CustomOAuth2User(
+				memberDto,
+				oidcUser.getAttributes(),
+				oidcUser.getIdToken(),
+				oidcUser.getUserInfo()
+			);
+		}
+
+		return new CustomOAuth2User(memberDto, oAuth2User.getAttributes());
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/user/CustomOAuth2User.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/user/CustomOAuth2User.java
@@ -1,0 +1,61 @@
+package com.comatching.auth.global.security.oauth2.user;
+
+import java.util.Map;
+
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.comatching.auth.global.security.UserPrincipal;
+import com.comatching.common.domain.enums.SocialType;
+import com.comatching.common.dto.auth.MemberLoginDto;
+
+import lombok.Getter;
+
+@Getter
+public class CustomOAuth2User extends UserPrincipal implements OidcUser, OAuth2User {
+
+	private final Map<String, Object> attributes;
+	private final OidcIdToken idToken;
+	private final OidcUserInfo userInfo;
+
+	public CustomOAuth2User(MemberLoginDto memberDto, Map<String, Object> attributes, OidcIdToken idToken, OidcUserInfo userInfo) {
+		super(memberDto);
+		this.attributes = attributes;
+		this.idToken = idToken;
+		this.userInfo = userInfo;
+	}
+
+	public CustomOAuth2User(MemberLoginDto memberDto, Map<String, Object> attributes) {
+		super(memberDto);
+		this.attributes = attributes;
+		this.idToken = null;
+		this.userInfo = null;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public Map<String, Object> getClaims() {
+		return this.idToken != null ? this.idToken.getClaims() : null;
+	}
+
+	@Override
+	public OidcIdToken getIdToken() {
+		return this.idToken;
+	}
+
+	@Override
+	public String getName() {
+		return String.valueOf(super.getId());
+	}
+
+	@Override
+	public OidcUserInfo getUserInfo() {
+		return this.userInfo;
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/user/OAuth2ProviderUserInfo.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/user/OAuth2ProviderUserInfo.java
@@ -1,0 +1,19 @@
+package com.comatching.auth.global.security.oauth2.user;
+
+import java.util.Map;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+
+import lombok.Getter;
+
+@Getter
+public abstract class OAuth2ProviderUserInfo implements OAuth2UserInfo {
+
+	private final Map<String, Object> attributes;
+	private final ClientRegistration clientRegistration;
+
+	public OAuth2ProviderUserInfo(Map<String, Object> attributes, ClientRegistration clientRegistration) {
+		this.attributes = attributes;
+		this.clientRegistration = clientRegistration;
+	}
+}

--- a/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/user/OAuth2UserInfo.java
+++ b/auth-service/src/main/java/com/comatching/auth/global/security/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,12 @@
+package com.comatching.auth.global.security.oauth2.user;
+
+import java.util.Map;
+
+public interface OAuth2UserInfo {
+
+	String getProviderId();
+	String getProvider();
+	String getEmail();
+	String getNickname();
+	Map<String, Object> getAttributes();
+}

--- a/auth-service/src/main/java/com/comatching/auth/infra/client/MemberServiceClient.java
+++ b/auth-service/src/main/java/com/comatching/auth/infra/client/MemberServiceClient.java
@@ -2,9 +2,12 @@ package com.comatching.auth.infra.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.comatching.common.dto.auth.MemberLoginDto;
+import com.comatching.common.dto.auth.SocialLoginRequestDto;
 
 // url: 로컬 테스트용 (배포시 제거)
 @FeignClient(name = "member-service", url = "${member-service.url:}")
@@ -16,4 +19,7 @@ public interface MemberServiceClient {
 
 	@GetMapping("/api/internal/members/login-info")
 	MemberLoginDto getMemberById(@RequestParam("id") Long id);
+
+	@PostMapping("/api/v1/members/social-login")
+	MemberLoginDto socialLogin(@RequestBody SocialLoginRequestDto request);
 }

--- a/auth-service/src/test/java/com/comatching/auth/global/security/refresh/controller/AuthReissueFlowTest.java
+++ b/auth-service/src/test/java/com/comatching/auth/global/security/refresh/controller/AuthReissueFlowTest.java
@@ -13,10 +13,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.comatching.auth.domain.controller.AuthController;
 import com.comatching.auth.domain.dto.TokenResponse;
 import com.comatching.auth.global.config.SecurityConfig;
 import com.comatching.auth.global.security.refresh.repository.RefreshTokenRepository;
-import com.comatching.auth.global.security.refresh.service.RefreshTokenService;
+import com.comatching.auth.domain.service.AuthService;
 import com.comatching.auth.global.security.service.CustomUserDetailsService;
 import com.comatching.auth.infra.client.MemberServiceClient;
 import com.comatching.common.service.S3Service;
@@ -24,7 +25,7 @@ import com.comatching.common.util.JwtUtil;
 
 import jakarta.servlet.http.Cookie;
 
-@WebMvcTest(RefreshTokenController.class)
+@WebMvcTest(AuthController.class)
 @Import({SecurityConfig.class, JwtUtil.class})
 class AuthReissueFlowTest {
 
@@ -32,7 +33,7 @@ class AuthReissueFlowTest {
 	private MockMvc mockMvc;
 
 	@MockitoBean
-	private RefreshTokenService refreshTokenService;
+	private AuthService authService;
 
 	@MockitoBean
 	private CustomUserDetailsService customUserDetailsService;
@@ -52,7 +53,7 @@ class AuthReissueFlowTest {
 		String oldRefreshToken = "old_refresh_token";
 		TokenResponse mockResponse = new TokenResponse("new_access", "new_refresh");
 
-		given(refreshTokenService.reissue(oldRefreshToken)).willReturn(mockResponse);
+		given(authService.reissue(oldRefreshToken)).willReturn(mockResponse);
 
 		//when
 		ResultActions result = mockMvc.perform(post("/auth/reissue")

--- a/auth-service/src/test/java/com/comatching/auth/global/security/refresh/service/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/comatching/auth/global/security/refresh/service/AuthServiceTest.java
@@ -2,11 +2,9 @@ package com.comatching.auth.global.security.refresh.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.comatching.auth.domain.dto.TokenResponse;
+import com.comatching.auth.domain.service.AuthService;
 import com.comatching.auth.global.security.refresh.RefreshToken;
 import com.comatching.auth.global.security.refresh.repository.RefreshTokenRepository;
 import com.comatching.auth.infra.client.MemberServiceClient;
@@ -25,7 +24,7 @@ import com.comatching.common.util.JwtUtil;
 import io.jsonwebtoken.Claims;
 
 @ExtendWith(MockitoExtension.class)
-class RefreshTokenServiceTest {
+class AuthServiceTest {
 
 	@Mock
 	private JwtUtil jwtUtil;
@@ -37,7 +36,7 @@ class RefreshTokenServiceTest {
 	private MemberServiceClient memberServiceClient;
 
 	@InjectMocks
-	private RefreshTokenService refreshTokenService;
+	private AuthService authService;
 
 	@Test
 	void reissue_Success() {
@@ -61,7 +60,7 @@ class RefreshTokenServiceTest {
 		given(jwtUtil.createRefreshToken(anyLong())).willReturn("new_refresh");
 
 		//when
-		TokenResponse response = refreshTokenService.reissue(oldRefreshToken);
+		TokenResponse response = authService.reissue(oldRefreshToken);
 
 		//then
 		assertThat(response.accessToken()).isEqualTo("new_access");
@@ -87,7 +86,7 @@ class RefreshTokenServiceTest {
 		given(refreshTokenRepository.findById(memberId)).willReturn(Optional.of(redisToken));
 
 		// when & then
-		assertThatThrownBy(() -> refreshTokenService.reissue(stolenToken))
+		assertThatThrownBy(() -> authService.reissue(stolenToken))
 			.isInstanceOf(BusinessException.class)
 			.hasMessageContaining("유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요.");
 
@@ -106,7 +105,7 @@ class RefreshTokenServiceTest {
 		given(refreshTokenRepository.existsById(memberId)).willReturn(true);
 
 		//when
-		refreshTokenService.logout(token);
+		authService.logout(token);
 
 		//then
 		verify(refreshTokenRepository).deleteById(memberId);
@@ -121,7 +120,7 @@ class RefreshTokenServiceTest {
 			.willThrow(new BusinessException(GeneralErrorCode.UNAUTHORIZED, "Invalid Token"));
 
 		// when
-		refreshTokenService.logout(invalidToken);
+		authService.logout(invalidToken);
 
 		// then
 		verify(refreshTokenRepository, never()).deleteById(anyLong());

--- a/common-module/src/main/java/com/comatching/common/domain/enums/SocialType.java
+++ b/common-module/src/main/java/com/comatching/common/domain/enums/SocialType.java
@@ -1,0 +1,13 @@
+package com.comatching.common.domain.enums;
+
+public enum SocialType {
+
+	KAKAO,
+	NAVER,
+	LOCAL
+	;
+
+	public static SocialType from(String registrationId) {
+		return SocialType.valueOf(registrationId.toUpperCase());
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/dto/auth/SocialLoginRequestDto.java
+++ b/common-module/src/main/java/com/comatching/common/dto/auth/SocialLoginRequestDto.java
@@ -1,0 +1,11 @@
+package com.comatching.common.dto.auth;
+
+import com.comatching.common.domain.enums.SocialType;
+
+public record SocialLoginRequestDto(
+	String email,
+	String nickname,
+	SocialType provider,
+	String providerId
+) {
+}


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #7

## 📋 Summary
Spring Security OAuth2 Client를 활용하여 소셜 로그인 기능을 구현했습니다.
다양한 소셜 공급자(Provider) 확장에 용이하도록 **Strategy 패턴**을 적용했으며, 보안 강화를 위해 **OIDC(OpenID Connect)** 사용을 기본 원칙으로 하되 호환성을 위해 일반 OAuth2 흐름도 지원하도록 설계했습니다.

## 🛠 Key Changes

### 1. 확장성 있는 구조 (Strategy & Factory)
- **`OAuth2UserInfo` (Interface)**: 소셜마다 상이한 JSON 응답을 통일된 규격으로 처리
- **`KakaoUser`**: 카카오의 중첩된 JSON 구조(kakao_account 등)와 OIDC 표준 클레임(sub)을 모두 처리하는 방어 로직 적용
- **`OAuth2UserInfoFactory`**: 요청된 Provider(Enum)에 맞는 구현체를 동적으로 반환

### 2. OIDC & OAuth2 통합 처리
- **서비스 분리**: `CustomOidcUserService`(OIDC용)와 `CustomOAuth2UserService`(일반용)를 분리하여 프로토콜별 처리를 명확히 함
- **`SocialLoginService`**: 실제 비즈니스 로직(회원 정보 매핑, MSA 통신)을 담당하는 공통 서비스 계층 도입
- **`CustomOAuth2User`**: `UserPrincipal`을 상속받아 컨트롤러에서 일반/소셜 유저 구분 없이 `@AuthenticationPrincipal`로 접근 가능

### 3. Handler & Security
- **SuccessHandler**:
  - 인증 성공 후 JWT 발급 및 Redis 저장 (RTR 적용)
  - 프론트엔드 연동을 위해 쿠키(Cookie)에 토큰을 담아 리다이렉트 (`HttpOnly` RefreshToken)
- **FailureHandler**: 실패 원인을 파라미터(`?error=...`)로 전달하여 프론트 UX 대응 가능

### 4. MSA Integration
- Auth 서비스가 DB에 직접 접근하지 않고, `MemberServiceClient`를 통해 Member 서비스에 로그인/회원가입 요청을 위임

## ✅ Check List
- [x] 카카오 OIDC 로그인이 정상 동작하는가?
- [x] Member 서비스(Mock)와 연동하여 데이터가 올바르게 전달되는가?
- [x] 로그인 성공 시 쿠키가 정상적으로 구워지는가?