### PR TITLE
[Feat] 2단계 회원가입(계정/프로필 분리) 및 Gateway JWT 인증 도입

### DIFF
--- a/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupService.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupService.java
@@ -1,6 +1,7 @@
 package com.comatching.auth.domain.service.auth;
 
 import com.comatching.common.dto.auth.SignupRequest;
+import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.member.ProfileCreateRequest;
 import com.comatching.common.dto.member.ProfileResponse;
 
@@ -12,5 +13,5 @@ public interface SignupService {
 	void signup(SignupRequest request);
 
 	// 프로필 + 토큰 갱신
-	ProfileResponse completeSignup(ProfileCreateRequest request, HttpServletResponse response);
+	ProfileResponse completeSignup(MemberInfo memberInfo, ProfileCreateRequest request, HttpServletResponse response);
 }

--- a/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupServiceImpl.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupServiceImpl.java
@@ -14,6 +14,7 @@ import com.comatching.common.domain.enums.MemberRole;
 import com.comatching.common.domain.enums.MemberStatus;
 import com.comatching.common.dto.auth.MemberCreateRequest;
 import com.comatching.common.dto.auth.SignupRequest;
+import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.member.ProfileCreateRequest;
 import com.comatching.common.dto.member.ProfileResponse;
 import com.comatching.common.exception.BusinessException;
@@ -54,10 +55,10 @@ public class SignupServiceImpl implements SignupService {
 
 	@Override
 	@Transactional
-	public ProfileResponse completeSignup(ProfileCreateRequest request, HttpServletResponse response) {
+	public ProfileResponse completeSignup(MemberInfo memberInfo, ProfileCreateRequest request, HttpServletResponse response) {
 
 		// Member Service에 프로필 생성 요청
-		ProfileResponse profileResponse = memberServiceClient.createProfile(request);
+		ProfileResponse profileResponse = memberServiceClient.createProfile(memberInfo.memberId(), request);
 
 		Long memberId = profileResponse.memberId();
 		String email = profileResponse.email();

--- a/auth-service/src/main/java/com/comatching/auth/domain/service/mail/EmailServiceImpl.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/service/mail/EmailServiceImpl.java
@@ -17,9 +17,7 @@ import com.comatching.common.exception.BusinessException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
@@ -40,7 +38,6 @@ public class EmailServiceImpl implements EmailService {
 	public void sendAuthCode(String email) {
 
 		String authCode = createCode();
-		log.info("create authcode={}", authCode);
 
 		redisTemplate.opsForValue().set(
 			AUTH_CODE_PREFIX + email,
@@ -62,8 +59,6 @@ public class EmailServiceImpl implements EmailService {
 
 		String key = AUTH_CODE_PREFIX + email;
 		String storedCode = redisTemplate.opsForValue().get(AUTH_CODE_PREFIX + email);
-
-		log.info("storedCode={}", storedCode);
 
 		if (storedCode == null || !storedCode.equals(code)) {
 			throw new BusinessException(AuthErrorCode.INVALID_AUTH_CODE);

--- a/auth-service/src/main/java/com/comatching/auth/infra/client/MemberServiceClient.java
+++ b/auth-service/src/main/java/com/comatching/auth/infra/client/MemberServiceClient.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.comatching.common.dto.auth.MemberLoginDto;
@@ -29,5 +30,8 @@ public interface MemberServiceClient {
 	void createMember(@RequestBody MemberCreateRequest request);
 
 	@PostMapping("/profile")
-	ProfileResponse createProfile(@RequestBody ProfileCreateRequest request);
+	ProfileResponse createProfile(
+		@RequestHeader("X-Member-Id") Long memberId,
+		@RequestBody ProfileCreateRequest request
+	);
 }

--- a/auth-service/src/main/java/com/comatching/auth/infra/controller/AuthController.java
+++ b/auth-service/src/main/java/com/comatching/auth/infra/controller/AuthController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.comatching.auth.domain.dto.TokenResponse;
 import com.comatching.auth.domain.service.auth.AuthService;
 import com.comatching.auth.domain.service.auth.SignupService;
+import com.comatching.common.annotation.CurrentMember;
 import com.comatching.common.dto.auth.SignupRequest;
+import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.member.ProfileCreateRequest;
 import com.comatching.common.dto.member.ProfileResponse;
 import com.comatching.common.dto.response.ApiResponse;
@@ -36,10 +38,11 @@ public class AuthController {
 
 	@PostMapping("/signup/profile")
 	public ResponseEntity<ProfileResponse> completeSignup(
+		@CurrentMember MemberInfo memberInfo,
 		@RequestBody ProfileCreateRequest request,
 		HttpServletResponse response
 	) {
-		ProfileResponse result = signupService.completeSignup(request, response);
+		ProfileResponse result = signupService.completeSignup(memberInfo, request, response);
 		return ResponseEntity.ok(result);
 	}
 

--- a/auth-service/src/test/java/com/comatching/auth/domain/service/auth/SignupServiceImplTest.java
+++ b/auth-service/src/test/java/com/comatching/auth/domain/service/auth/SignupServiceImplTest.java
@@ -21,6 +21,7 @@ import com.comatching.auth.infra.client.MemberServiceClient;
 import com.comatching.common.domain.enums.Gender;
 import com.comatching.common.domain.enums.MemberRole;
 import com.comatching.common.dto.auth.SignupRequest;
+import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.member.ProfileCreateRequest;
 import com.comatching.common.dto.member.ProfileResponse;
 import com.comatching.common.exception.BusinessException;
@@ -101,7 +102,9 @@ class SignupServiceImplTest {
 			null, null
 		);
 
-		given(memberServiceClient.createProfile(request)).willReturn(mockProfileResponse);
+		MemberInfo memberInfo = new MemberInfo(memberId, "test@test.com", "ROLE_GUEST");
+
+		given(memberServiceClient.createProfile(memberId, request)).willReturn(mockProfileResponse);
 
 		String accessToken = "mock-access-token";
 		String refreshToken = "mock-refresh-token";
@@ -109,7 +112,7 @@ class SignupServiceImplTest {
 		given(jwtUtil.createRefreshToken(anyLong())).willReturn(refreshToken);
 
 		// when
-		ProfileResponse result = signupService.completeSignup(request, response);
+		ProfileResponse result = signupService.completeSignup(memberInfo, request, response);
 
 		// then
 		assertThat(result.memberId()).isEqualTo(memberId);

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 description = 'common-module'
 
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
 bootJar { enabled = false }
 jar { enabled = true }
 
@@ -33,4 +37,13 @@ dependencies {
 
 	// aws s3
 	api 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2'
+
+	// feign
+	api 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }

--- a/common-module/src/main/java/com/comatching/common/annotation/CurrentMember.java
+++ b/common-module/src/main/java/com/comatching/common/annotation/CurrentMember.java
@@ -1,0 +1,11 @@
+package com.comatching.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentMember {
+}

--- a/common-module/src/main/java/com/comatching/common/config/WebConfig.java
+++ b/common-module/src/main/java/com/comatching/common/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.comatching.common.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.comatching.common.resolver.MemberInfoArgumentResolver;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new MemberInfoArgumentResolver());
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/dto/member/MemberInfo.java
+++ b/common-module/src/main/java/com/comatching/common/dto/member/MemberInfo.java
@@ -1,0 +1,8 @@
+package com.comatching.common.dto.member;
+
+public record MemberInfo(
+	Long memberId,
+	String email,
+	String role
+) {
+}

--- a/common-module/src/main/java/com/comatching/common/resolver/MemberInfoArgumentResolver.java
+++ b/common-module/src/main/java/com/comatching/common/resolver/MemberInfoArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.comatching.common.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.comatching.common.annotation.CurrentMember;
+import com.comatching.common.dto.member.MemberInfo;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class MemberInfoArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(CurrentMember.class)
+			&& parameter.getParameterType().equals(MemberInfo.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+		HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+		String memberIdHeader = request.getHeader("X-Member-Id");
+		String email = request.getHeader("X-Member-Email");
+		String role = request.getHeader("X-Member-Role");
+
+		if (memberIdHeader == null) {
+			throw new IllegalArgumentException("인증 헤더가 누락되었습니다.");
+		}
+
+		return new MemberInfo(Long.parseLong(memberIdHeader), email, role);
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/util/CookieUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/CookieUtil.java
@@ -23,7 +23,7 @@ public class CookieUtil {
 	// Refresh Token 쿠키
 	public static ResponseCookie createRefreshTokenCookie(String refreshToken) {
 		return ResponseCookie.from("refreshToken", refreshToken)
-			.path("/auth/reissue")
+			.path("/api/auth")
 			.httpOnly(true)
 			.secure(false) // HTTPS 환경에서는 true
 			.maxAge(Duration.ofDays(7).toSeconds())
@@ -34,7 +34,7 @@ public class CookieUtil {
 	// 로그아웃 시 쿠키 삭제
 	public static ResponseCookie createExpiredCookie(String cookieName) {
 		return ResponseCookie.from(cookieName, "")
-			.path("/")
+			.path(cookieName.equals("accessToken") ? "/" :"/api/auth")
 			.httpOnly(true)
 			.maxAge(0) // 즉시 만료
 			.build();

--- a/common-module/src/main/java/com/comatching/common/util/JwtUtil.java
+++ b/common-module/src/main/java/com/comatching/common/util/JwtUtil.java
@@ -15,6 +15,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,7 +31,10 @@ public class JwtUtil {
 		@Value("${jwt.secret}") String secret,
 		@Value("${jwt.access-token.expiration}") long accessTokenValidity,
 		@Value("${jwt.refresh-token.expiration}") long refreshTokenValidity) {
-		this.key = Keys.hmacShaKeyFor(secret.getBytes());
+
+		byte[] keyBytes = Decoders.BASE64.decode(secret);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+
 		this.accessTokenValidity = accessTokenValidity;
 		this.refreshTokenValidity = refreshTokenValidity;
 	}

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -11,6 +11,12 @@ ext {
 }
 
 dependencies {
+    implementation (project(':common-module')) {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-jpa'
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-security'
+        exclude group: 'io.awspring.cloud', module: 'spring-cloud-aws-starter-s3'
+    }
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/gateway-service/src/main/java/com/comatching/gateway/GatewayServiceApplication.java
+++ b/gateway-service/src/main/java/com/comatching/gateway/GatewayServiceApplication.java
@@ -2,8 +2,33 @@ package com.comatching.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 
-@SpringBootApplication
+import com.comatching.common.exception.handler.GlobalExceptionHandler;
+
+@SpringBootApplication(
+	exclude = {
+		DataSourceAutoConfiguration.class,
+		HibernateJpaAutoConfiguration.class
+	}
+)
+@ComponentScan(
+	basePackages = {
+		"com.comatching.gateway",
+		"com.comatching.common.util",
+		"com.comatching.common.dto",
+		"com.comatching.common.exception"
+	},
+	excludeFilters = {
+		@ComponentScan.Filter(
+			type = FilterType.ASSIGNABLE_TYPE,
+			classes = GlobalExceptionHandler.class
+		)
+	}
+)
 public class GatewayServiceApplication {
 
 	public static void main(String[] args) {

--- a/gateway-service/src/main/java/com/comatching/gateway/exception/GatewayErrorCode.java
+++ b/gateway-service/src/main/java/com/comatching/gateway/exception/GatewayErrorCode.java
@@ -1,0 +1,23 @@
+package com.comatching.gateway.exception;
+
+import com.comatching.common.exception.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatewayErrorCode implements ErrorCode {
+
+	// JWT / Auth 관련
+	TOKEN_MISSING("GATEWAY-001", HttpStatus.UNAUTHORIZED, "토큰이 누락되었습니다."),
+	TOKEN_INVALID("GATEWAY-002", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	TOKEN_EXPIRED("GATEWAY-003", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+
+	// 기타 Gateway 오류
+	SERVER_ERROR("GATEWAY-004", HttpStatus.INTERNAL_SERVER_ERROR, "게이트웨이 내부 오류입니다.");
+
+	private final String code;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/gateway-service/src/main/java/com/comatching/gateway/filter/AuthorizationHeaderFilter.java
+++ b/gateway-service/src/main/java/com/comatching/gateway/filter/AuthorizationHeaderFilter.java
@@ -1,0 +1,96 @@
+package com.comatching.gateway.filter;
+
+import com.comatching.common.dto.response.ApiResponse;
+import com.comatching.common.exception.code.ErrorCode;
+import com.comatching.common.util.JwtUtil;
+import com.comatching.gateway.exception.GatewayErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j
+public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<AuthorizationHeaderFilter.Config> {
+
+	private final JwtUtil jwtUtil;
+	private final ObjectMapper objectMapper;
+
+	public AuthorizationHeaderFilter(JwtUtil jwtUtil, ObjectMapper objectMapper) {
+		super(Config.class);
+		this.jwtUtil = jwtUtil;
+		this.objectMapper = objectMapper;
+	}
+
+	public static class Config {
+	}
+
+	@Override
+	public GatewayFilter apply(Config config) {
+		return (exchange, chain) -> {
+			ServerHttpRequest request = exchange.getRequest();
+
+			// 토큰 추출
+			String accessToken = extractToken(request);
+			if (accessToken == null) {
+				return onError(exchange, GatewayErrorCode.TOKEN_MISSING);
+			}
+
+			// 토큰 유효성 검증
+			if (!jwtUtil.validateToken(accessToken)) {
+				return onError(exchange, GatewayErrorCode.TOKEN_INVALID);
+			}
+
+			// 사용자 정보 추출 및 헤더 주입
+			try {
+				Claims claims = jwtUtil.parseToken(accessToken);
+				ServerHttpRequest modifiedRequest = request.mutate()
+					.header("X-Member-Id", claims.getSubject())
+					.header("X-Member-Email", claims.get("email", String.class))
+					.header("X-Member-Role", claims.get("role", String.class))
+					.build();
+
+				return chain.filter(exchange.mutate().request(modifiedRequest).build());
+			} catch (Exception e) {
+				log.error("Token parsing error: {}", e.getMessage());
+				return onError(exchange, GatewayErrorCode.TOKEN_INVALID);
+			}
+		};
+	}
+
+	private String extractToken(ServerHttpRequest request) {
+		HttpCookie cookie = request.getCookies().getFirst("accessToken");
+		if (cookie != null) {
+			return cookie.getValue();
+		}
+		return null;
+	}
+
+	private Mono<Void> onError(ServerWebExchange exchange, ErrorCode errorCode) {
+		ServerHttpResponse response = exchange.getResponse();
+		response.setStatusCode(errorCode.getHttpStatus());
+		response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+		ApiResponse<Object> apiResponse = ApiResponse.errorResponse(errorCode);
+
+		try {
+			byte[] bytes = objectMapper.writeValueAsBytes(apiResponse);
+			DataBuffer buffer = response.bufferFactory().wrap(bytes);
+			return response.writeWith(Mono.just(buffer));
+		} catch (JsonProcessingException e) {
+			return response.setComplete();
+		}
+	}
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -23,10 +23,15 @@ spring:
 
           # 2. 라우팅 규칙
           routes:
-            - id: auth-service
+            - id: auth-service-public
               uri: http://localhost:9000
               predicates:
-                - Path=/api/auth/**
+                - Path=/api/auth/login, /api/auth/signup, /api/auth/email/**
+
+            - id: auth-service-protected
+              uri: http://localhost:9000
+              predicates:
+                - Path=/api/auth/signup/profile, /api/auth/logout, /api/auth/reissue
               filters:
                 - AuthorizationHeaderFilter
 

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -26,7 +26,9 @@ spring:
             - id: auth-service
               uri: http://localhost:9000
               predicates:
-                - Path=/api/auth/**, /api/login/**, /api/oauth2/**
+                - Path=/api/auth/**
+              filters:
+                - AuthorizationHeaderFilter
 
             - id: auth-service-swagger
               uri: http://localhost:9000
@@ -38,7 +40,9 @@ spring:
             - id: matching-service
               uri: http://localhost:9001
               predicates:
-                - Path=/api/matching/**
+                - Path=/api/matching/**, /api/internal/matching/**
+              filters:
+                - AuthorizationHeaderFilter
 
             - id: matching-service-swagger
               uri: http://localhost:9001
@@ -50,7 +54,9 @@ spring:
             - id: member-service
               uri: http://localhost:9002
               predicates:
-                - Path=/api/member/**, /api/users/**
+                - Path=/api/member/**, /api/internal/members/**
+              filters:
+                - AuthorizationHeaderFilter
 
             - id: member-service-swagger
               uri: http://localhost:9002
@@ -62,7 +68,9 @@ spring:
             - id: chat-service
               uri: http://localhost:9003
               predicates:
-                - Path=/api/chat/**, /ws/**
+                - Path=/api/chat/**, /api/internal/chat/**, /ws/**
+              filters:
+                - AuthorizationHeaderFilter
 
             - id: chat-service-swagger
               uri: http://localhost:9003
@@ -75,6 +83,8 @@ spring:
               uri: http://localhost:9004
               predicates:
                 - Path=/api/payment/**
+              filters:
+                - AuthorizationHeaderFilter
 
             - id: payment-service-swagger
               uri: http://localhost:9004

--- a/member-service/build.gradle
+++ b/member-service/build.gradle
@@ -6,6 +6,10 @@ plugins {
 
 description = 'member-service'
 
+ext {
+	set('springCloudVersion', "2025.0.1")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -14,4 +18,10 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }

--- a/member-service/src/main/java/com/comatching/member/domain/entity/Profile.java
+++ b/member-service/src/main/java/com/comatching/member/domain/entity/Profile.java
@@ -40,6 +40,7 @@ public class Profile {
 
 	private String profileImageUrl;
 
+	@Enumerated(EnumType.STRING)
 	private SocialAccountType socialAccountType;
 
 	private String socialAccountId;

--- a/member-service/src/main/java/com/comatching/member/infra/controller/ProfileController.java
+++ b/member-service/src/main/java/com/comatching/member/infra/controller/ProfileController.java
@@ -1,6 +1,5 @@
 package com.comatching.member.infra.controller;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -9,7 +8,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.comatching.common.dto.member.ProfileCreateRequest;
 import com.comatching.common.dto.member.ProfileResponse;
-import com.comatching.common.dto.response.ApiResponse;
 import com.comatching.member.domain.service.ProfileService;
 
 import lombok.RequiredArgsConstructor;
@@ -22,11 +20,10 @@ public class ProfileController {
 	private final ProfileService profileService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<ProfileResponse>> createProfile(
-		@RequestHeader("X-Member-Id") Long memberId, // Gateway에서 헤더로 넣어준 ID 사용
+	public ProfileResponse createProfile(
+		@RequestHeader("X-Member-Id") Long memberId,
 		@RequestBody ProfileCreateRequest request
 	) {
-		ProfileResponse profile = profileService.createProfile(memberId, request);
-		return ResponseEntity.ok(ApiResponse.ok(profile));
+		return profileService.createProfile(memberId, request);
 	}
 }

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -20,5 +20,5 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
-    show-sql: true
+      ddl-auto: create
+    show-sql: false

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -20,5 +20,5 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #11

## 📋 Summary
기존의 인증 및 회원가입 로직을 MSA 구조에 맞춰 분리하고 고도화했습니다.
`auth-service`에서는 **이메일 인증 및 2단계 회원가입(계정 생성 -> 프로필 입력)** 프로세스를 담당하며, `gateway-service`는 **JWT 토큰 검증 및 라우팅**을 담당하도록 구현했습니다.

## 🛠 Key Changes

### 1. Member Service (Domain & Logic)
- **Entity 분리**: `Member`(인증 핵심)와 `Profile`(상세 정보) 엔티티 분리 및 1:1 매핑.
- **Role 승격 로직**:
  - 최초 가입 시 `ROLE_GUEST` 상태.
  - 프로필 입력 완료 시 `upgradeRoleToUser()` 메서드를 통해 `ROLE_USER`로 승격.
- **Internal API**: Auth 서비스와의 통신을 위한 내부용 Controller (`/api/internal/members`) 구현.

### 2. Auth Service (Signup Flow)
- **이메일 인증**: Redis를 활용한 인증 코드 발송(5분) 및 검증(30분) 로직 (`EmailService`).
- **회원가입 플로우**:
  - `SignupService`: 이메일 인증 확인 -> 계정 생성(Feign) -> 프로필 입력 -> 토큰 발급.
  - `AuthController`: 쿠키 Path 설정을 통해 리프레시 토큰 보안 강화 (`/api/auth`).

### 3. Gateway Service (Security & Routing)
- **JWT 인증 필터 (`AuthorizationHeaderFilter`)**:
  - JWT 유효성 검증 및 Claims 파싱.
  - `X-Member-Id`, `X-Member-Role` 등 사용자 정보를 헤더에 담아 Downstream 서비스로 전달.
- **라우팅 규칙 (`application.yml`)**:
  - 공개 API (`/api/auth/**`, Docs)와 보호 API (`/api/matching/**`, `/api/members/**`) 분리.
- **Global Exception Handler**: Feign Client 예외 및 Gateway 내부 에러를 JSON 형태로 표준화하여 반환.

### 4. Common & Infrastructure
- **Resolver**: `@CurrentMember` 어노테이션 및 `MemberInfoArgumentResolver`를 구현하여 헤더 기반의 유저 정보 주입 지원.
- **Feign Client**: 서비스 간 데이터 전송을 위한 DTO 정의 및 에러 디코딩 처리.

## 🔬 Test Checklist
- [x] 이메일 인증 코드가 정상적으로 발송되고 Redis에 저장되는가? (TTL 확인)
- [x] 인증 코드 검증 성공 시 `VERIFIED` 상태가 유지되는가?
- [x] 이메일 인증 없이 회원가입 시도 시 예외가 발생하는가?
- [x] 프로필 입력 완료 후 `member-service` DB에 Profile이 적재되고 Role이 USER로 변경되는가?
- [x] Gateway를 통해 보호된 리소스 접근 시 JWT 검증이 정상 작동하는가?
- [x] 최종 가입 완료 시점에 Access/Refresh Token이 쿠키(Path 설정 포함)에 정상 발급되는가?

## 🎸 기타 (Notes)
- `MemberService`의 `ddl-auto` 설정을 `update`로 변경했습니다.
- Gateway 필터 적용을 위해 `common-module` 의존성을 업데이트했습니다.