### PR TITLE
feat: 분산 락 기반 매칭 동시성 제어 추가

### DIFF
--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
 	// kafka
 	api 'org.springframework.kafka:spring-kafka'
+
+	// redisson
+	api 'org.redisson:redisson-spring-boot-starter:3.27.0'
 }
 
 dependencyManagement {

--- a/common-module/src/main/java/com/comatching/common/annotation/DistributedLock.java
+++ b/common-module/src/main/java/com/comatching/common/annotation/DistributedLock.java
@@ -1,0 +1,37 @@
+package com.comatching.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+	/**
+	 * 락의 이름 (Key)
+	 */
+	String key();
+
+	/**
+	 * 락의 식별자 (SpEL 표현식)
+	 */
+	String identifier();
+
+	/**
+	 * 락 획득을 위해 대기하는 시간 (기본 5초)
+	 */
+	long waitTime() default 5L;
+
+	/**
+	 * 락을 잡고 있는 최대 시간 (기본 3초)
+	 */
+	long leaseTime() default 3L;
+
+	/**
+	 * 시간 단위
+	 */
+	TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/common-module/src/main/java/com/comatching/common/aop/AopForTransaction.java
+++ b/common-module/src/main/java/com/comatching/common/aop/AopForTransaction.java
@@ -1,0 +1,15 @@
+package com.comatching.common.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public Object proceed(ProceedingJoinPoint joinPoint) throws Throwable {
+		return joinPoint.proceed();
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/aop/CustomSpringELParser.java
+++ b/common-module/src/main/java/com/comatching/common/aop/CustomSpringELParser.java
@@ -1,0 +1,21 @@
+package com.comatching.common.aop;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+
+	private CustomSpringELParser() {}
+
+	public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+		ExpressionParser parser = new SpelExpressionParser();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+
+		for (int i = 0; i < parameterNames.length; i++) {
+			context.setVariable(parameterNames[i], args[i]);
+		}
+
+		return parser.parseExpression(key).getValue(context, Object.class);
+	}
+}

--- a/common-module/src/main/java/com/comatching/common/aop/DistributedLockAspect.java
+++ b/common-module/src/main/java/com/comatching/common/aop/DistributedLockAspect.java
@@ -1,0 +1,75 @@
+package com.comatching.common.aop;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import com.comatching.common.annotation.DistributedLock;
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+	private final RedissonClient redissonClient;
+	private final AopForTransaction aopForTransaction;
+
+	@Around("@annotation(com.comatching.common.annotation.DistributedLock)")
+	public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		Method method = signature.getMethod();
+		DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+		// 락 키 생성
+		String key = distributedLock.key() + ":" + CustomSpringELParser.getDynamicValue(
+			signature.getParameterNames(),
+			joinPoint.getArgs(),
+			distributedLock.identifier()
+		);
+
+		RLock rLock = redissonClient.getLock(key);
+
+		try {
+			// 락 획득 시도
+			boolean available = rLock.tryLock(
+				distributedLock.waitTime(),
+				distributedLock.leaseTime(),
+				distributedLock.timeUnit()
+			);
+
+			if (!available) {
+				log.warn("락 획득 실패 - Key: {}", key);
+				throw new BusinessException(GeneralErrorCode.TOO_MANY_REQUEST);
+			}
+
+			log.info("락 획득 성공 - Key: {}", key);
+
+			return aopForTransaction.proceed(joinPoint);
+		} catch (InterruptedException e) {
+			throw new InterruptedException();
+		} finally {
+			try {
+				if (rLock.isLocked() && rLock.isHeldByCurrentThread()) {
+					rLock.unlock();
+					log.info("락 해제 성공 - Key: {}", key);
+				}
+			} catch (IllegalMonitorStateException e) {
+				log.error("락 해제 중 오류 발생 - Key: {}", key, e);
+			}
+		}
+	}
+
+}

--- a/common-module/src/main/java/com/comatching/common/exception/code/GeneralErrorCode.java
+++ b/common-module/src/main/java/com/comatching/common/exception/code/GeneralErrorCode.java
@@ -15,6 +15,7 @@ public enum GeneralErrorCode implements ErrorCode {
 	TYPE_MISMATCH("GEN-005", HttpStatus.BAD_REQUEST, "파라미터 타입이 일치하지 않습니다."),
 	JSON_PARSE_ERROR("GEN-006", HttpStatus.BAD_REQUEST, "JSON 파싱에 실패했습니다."),
 	FILE_EXPIRED("GEN-103", HttpStatus.BAD_REQUEST, "파일의 유효기간이 만료되었습니다."),
+	TOO_MANY_REQUEST("GEN-104", HttpStatus.BAD_REQUEST, "요청이 너무 많습니다."),
 
 	// 404 Not Found
 	NOT_FOUND("GEN-007", HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),

--- a/matching-service/build.gradle
+++ b/matching-service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingServiceImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.comatching.common.annotation.DistributedLock;
 import com.comatching.common.domain.enums.Gender;
 import com.comatching.common.dto.member.ProfileResponse;
 import com.comatching.common.exception.BusinessException;
@@ -36,6 +37,7 @@ public class MatchingServiceImpl implements MatchingService {
 	private final MemberClient memberClient;
 
 	@Override
+	@DistributedLock(key = "MATCHING_REQUEST", identifier = "#memberId")
 	public MatchingResponse match(Long memberId, MatchingRequest request) {
 
 		ProfileResponse myProfile = memberClient.getProfile(memberId);

--- a/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingConcurrencyTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingConcurrencyTest.java
@@ -1,0 +1,102 @@
+package com.comatching.matching.domain.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.comatching.common.domain.enums.Gender;
+import com.comatching.common.domain.enums.Hobby;
+import com.comatching.common.dto.member.ProfileResponse;
+import com.comatching.matching.domain.dto.MatchingRequest;
+import com.comatching.matching.domain.entity.MatchingCandidate;
+import com.comatching.matching.domain.repository.candidate.MatchingCandidateRepository;
+import com.comatching.matching.infra.client.MemberClient;
+
+@SpringBootTest
+class MatchingConcurrencyTest {
+
+	@Autowired
+	private MatchingService matchingService;
+
+	@Autowired
+	private MatchingCandidateRepository candidateRepository;
+
+	@MockitoBean
+	private MemberClient memberClient;
+
+	@Test
+	void matchingConcurrencyTest() throws InterruptedException {
+		// given
+		int threadCount = 2;
+		// 멀티스레드 환경을 만들기 위한 실행기 (32개 스레드 풀)
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		// 모든 스레드가 준비될 때까지 기다렸다가 동시에 '땅!' 출발시키기 위한 장치
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		AtomicInteger successCount = new AtomicInteger();
+		AtomicInteger failCount = new AtomicInteger();
+
+		Long memberId = 1L; // 테스트할 유저 ID
+
+		MatchingCandidate partner = MatchingCandidate.create(
+			2L, 20L, Gender.FEMALE, "ISTJ", "디자인학과",
+			new HashSet<>(Collections.singletonList(Hobby.SOCCER)), LocalDate.of(2000, 11, 11), true
+		);
+		candidateRepository.save(partner);
+
+		MatchingRequest request = new MatchingRequest(
+			null, "IS", Hobby.Category.SPORTS, false
+		);
+
+		given(memberClient.getProfile(anyLong()))
+			.willReturn(ProfileResponse.builder()
+				.memberId(memberId)
+				.gender(Gender.MALE)
+				.mbti("ISTJ")
+				.major("컴퓨터공학과")
+				.birthDate(LocalDate.of(2000, 1, 1))
+				.build());
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					// 매칭 요청 실행
+					matchingService.match(memberId, request);
+					// 예외가 안 나면 성공 카운트 증가
+					successCount.getAndIncrement();
+				} catch (Exception e) {
+					// 락 획득 실패 등으로 예외가 나면 실패 카운트 증가
+					System.out.println("매칭 실패: " + e.getMessage());
+					failCount.getAndIncrement();
+				} finally {
+					latch.countDown(); // 작업 끝났음을 알림
+				}
+			});
+		}
+
+		latch.await(); // 모든 스레드가 끝날 때까지 대기
+
+		// then
+		System.out.println("=== 테스트 결과 ===");
+		System.out.println("성공 횟수: " + successCount.get());
+		System.out.println("실패 횟수: " + failCount.get());
+
+		// 검증: 성공은 무조건 1번이어야 함 (락이 제대로 동작했다면)
+		assertThat(successCount.get()).isEqualTo(1);
+	}
+
+}

--- a/matching-service/src/test/resources/application.yml
+++ b/matching-service/src/test/resources/application.yml
@@ -1,0 +1,56 @@
+spring:
+  application:
+    name: matching-service-test
+
+  # 👇 [추가] H2 데이터베이스 설정
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # 👇 [추가] JPA 설정 (테스트 때만 테이블 자동 생성)
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop # 테스트 시작 시 생성, 종료 시 삭제
+    show-sql: false # 쿼리 나가는거 보고 싶으면 true
+    properties:
+      hibernate:
+        format_sql: true
+
+  # (기존 설정 유지)
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: matching-service-group
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+  cloud:
+    aws:
+      credentials:
+        access-key: SDFDSFSFDSFDSF
+        secret-key: SDFDFADASFSGVDDSGDGS
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: DSFDSFSDF
+
+# (기존 설정 유지)
+jwt:
+  secret: "thisdisddummydsecretdkeydfordtestdenvironmentdoverd256dbits"
+  access-token:
+    expiration: 3600000
+  refresh-token:
+    expiration: 1209600000
+
+# (기존 설정 유지)
+member-service:
+  url: "http://localhost:8080"


### PR DESCRIPTION
## 📋 개요
매칭 신청(`MatchingService.match`) 시 발생할 수 있는 동시성 이슈(Race Condition)를 해결하기 위해 Redis 기반의 분산 락(Distributed Lock)을 적용했습니다.

## 🛠 작업 내용
- **AOP 기반 분산 락 적용**: `@DistributedLock` 어노테이션을 통해 비즈니스 로직 침투를 최소화하며 락을 제어하도록 구성했습니다.
- **매칭 서비스 로직 수정**: `MatchingServiceImpl.match()` 메서드 진입 시 `memberId`를 키(Key)로 락을 획득합니다.
- **테스트 코드 보완**: 
    - `MatchingConcurrencyTest`에서 발생하던 NPE 문제(`birthDate` 누락)를 수정했습니다.
    - 멀티스레드 환경(ExecutorService)에서 동시에 요청을 보냈을 때, 1건만 성공하고 나머지는 실패하는지 검증을 완료했습니다.

## 🔍 핵심 변경 로직
```java
// MatchingServiceImpl.java
@Override
@DistributedLock(key = "MATCHING_REQUEST", identifier = "#memberId")
public MatchingResponse match(Long memberId, MatchingRequest request) {
    // ... 매칭 로직 ...
}