### PR TITLE
feat: 프로필 데이터 초기화 시 기본 닉네임 수정

### DIFF
--- a/member-service/src/main/java/com/comatching/member/domain/entity/Profile.java
+++ b/member-service/src/main/java/com/comatching/member/domain/entity/Profile.java
@@ -102,16 +102,13 @@ public class Profile {
 	}
 
 	public void clearProfileData() {
-		this.nickname = "(알 수 없음)";
+		this.nickname = "탈퇴한 사용자";
 		this.intro = null;
 		this.profileImageUrl = null;
 		this.birthDate = null;
 		this.socialAccountType = null;
 		this.socialAccountId = null;
-		this.university = "(알 수 없음)";
 		this.major = "(알 수 없음)";
-		this.hobbies.clear();
-		this.intros.clear();
 	}
 
 	public void update(


### PR DESCRIPTION
- 프로필 데이터 초기화 시 닉네임 값을 `"탈퇴한 사용자"`로 변경
- 불필요한 필드(`hobbies`, `intros`) 초기화 로직 제거