### PR TITLE
refactor: Set 타입 필드를 List로 변경 및 PagingResponse 적용

### DIFF
--- a/common-module/src/main/java/com/comatching/common/dto/response/PagingResponse.java
+++ b/common-module/src/main/java/com/comatching/common/dto/response/PagingResponse.java
@@ -15,7 +15,7 @@ public record PagingResponse<T>(
 	public static <T> PagingResponse<T> from(Page<T> page) {
 		return new PagingResponse<>(
 			page.getContent(),
-			page.getNumber() + 1,
+			page.getNumber(),
 			page.getSize(),
 			page.getTotalElements(),
 			page.getTotalPages(),

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -99,7 +99,7 @@ spring:
                 - RewritePath=/payment-doc/(?<segment>.*), /$\{segment}
 
             - id: item-service
-              uri: http://localhost:9005
+              uri: http://localhost:9006
               predicates:
                 - Path=/api/items/**, /api/internal/items/**
               filters:

--- a/item-service/src/main/java/com/comatching/item/domain/service/ItemHistoryService.java
+++ b/item-service/src/main/java/com/comatching/item/domain/service/ItemHistoryService.java
@@ -3,6 +3,7 @@ package com.comatching.item.domain.service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.comatching.common.dto.response.PagingResponse;
 import com.comatching.item.domain.dto.ItemHistoryResponse;
 import com.comatching.item.domain.enums.ItemHistoryType;
 import com.comatching.common.domain.enums.ItemType;
@@ -13,5 +14,5 @@ public interface ItemHistoryService {
 
 	Page<ItemHistoryResponse> getMyHistory(Long memberId, Pageable pageable);
 
-	Page<ItemHistoryResponse> searchMyHistory(Long memberId, ItemType itemType, ItemHistoryType historyType, Pageable pageable);
+	PagingResponse<ItemHistoryResponse> searchMyHistory(Long memberId, ItemType itemType, ItemHistoryType historyType, Pageable pageable);
 }

--- a/item-service/src/main/java/com/comatching/item/domain/service/ItemHistoryServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/service/ItemHistoryServiceImpl.java
@@ -5,10 +5,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.comatching.common.domain.enums.ItemType;
+import com.comatching.common.dto.response.PagingResponse;
 import com.comatching.item.domain.dto.ItemHistoryResponse;
 import com.comatching.item.domain.entity.ItemHistory;
 import com.comatching.item.domain.enums.ItemHistoryType;
-import com.comatching.common.domain.enums.ItemType;
 import com.comatching.item.domain.repository.ItemHistoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -16,12 +17,13 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class ItemHistoryServiceImpl implements ItemHistoryService{
+public class ItemHistoryServiceImpl implements ItemHistoryService {
 
 	private final ItemHistoryRepository historyRepository;
 
 	@Override
-	public void saveHistory(Long memberId, ItemType itemType, ItemHistoryType historyType, int quantity, String description) {
+	public void saveHistory(Long memberId, ItemType itemType, ItemHistoryType historyType, int quantity,
+		String description) {
 		ItemHistory history = ItemHistory.builder()
 			.memberId(memberId)
 			.itemType(itemType)
@@ -41,9 +43,13 @@ public class ItemHistoryServiceImpl implements ItemHistoryService{
 	}
 
 	@Override
-	public Page<ItemHistoryResponse> searchMyHistory(Long memberId, ItemType itemType, ItemHistoryType historyType,
+	@Transactional(readOnly = true)
+	public PagingResponse<ItemHistoryResponse> searchMyHistory(Long memberId, ItemType itemType,
+		ItemHistoryType historyType,
 		Pageable pageable) {
-		return historyRepository.searchHistory(memberId, itemType, historyType, pageable)
-			.map(ItemHistoryResponse::from);
+		return PagingResponse.from(
+			historyRepository.searchHistory(memberId, itemType, historyType, pageable)
+				.map(ItemHistoryResponse::from)
+		);
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/domain/service/ItemService.java
+++ b/item-service/src/main/java/com/comatching/item/domain/service/ItemService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.comatching.common.dto.item.AddItemRequest;
 import com.comatching.common.domain.enums.ItemType;
+import com.comatching.common.dto.response.PagingResponse;
 import com.comatching.item.domain.dto.ItemResponse;
 
 public interface ItemService {
@@ -13,5 +14,5 @@ public interface ItemService {
 
 	void addItem(Long memberId, AddItemRequest request);
 
-	Page<ItemResponse> getMyItems(Long memberId, ItemType itemType, Pageable pageable);
+	PagingResponse<ItemResponse> getMyItems(Long memberId, ItemType itemType, Pageable pageable);
 }

--- a/item-service/src/main/java/com/comatching/item/domain/service/ItemServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/service/ItemServiceImpl.java
@@ -3,18 +3,18 @@ package com.comatching.item.domain.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.comatching.common.domain.enums.ItemRoute;
-import com.comatching.common.exception.BusinessException;
+import com.comatching.common.domain.enums.ItemType;
 import com.comatching.common.dto.item.AddItemRequest;
+import com.comatching.common.dto.response.PagingResponse;
+import com.comatching.common.exception.BusinessException;
 import com.comatching.item.domain.dto.ItemResponse;
 import com.comatching.item.domain.entity.Item;
 import com.comatching.item.domain.enums.ItemHistoryType;
-import com.comatching.common.domain.enums.ItemType;
 import com.comatching.item.domain.repository.ItemRepository;
 import com.comatching.item.global.exception.ItemErrorCode;
 
@@ -65,7 +65,9 @@ public class ItemServiceImpl implements ItemService {
 	@Override
 	public void addItem(Long memberId, AddItemRequest request) {
 
-		LocalDateTime expiredAt = request.route().equals(ItemRoute.EVENT) ? LocalDateTime.now().plusDays(request.expiredAt()) : LocalDateTime.of(2099, 12, 31, 23, 59, 59);
+		LocalDateTime expiredAt =
+			request.route().equals(ItemRoute.EVENT) ? LocalDateTime.now().plusDays(request.expiredAt()) :
+				LocalDateTime.of(2099, 12, 31, 23, 59, 59);
 
 		Item item = Item.builder()
 			.memberId(memberId)
@@ -94,8 +96,10 @@ public class ItemServiceImpl implements ItemService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public Page<ItemResponse> getMyItems(Long memberId, ItemType itemType, Pageable pageable) {
-		return itemRepository.findMyUsableItems(memberId, itemType, pageable)
-			.map(ItemResponse::from);
+	public PagingResponse<ItemResponse> getMyItems(Long memberId, ItemType itemType, Pageable pageable) {
+		return PagingResponse.from(
+			itemRepository.findMyUsableItems(memberId, itemType, pageable)
+				.map(ItemResponse::from)
+		);
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/infra/controller/ItemController.java
+++ b/item-service/src/main/java/com/comatching/item/infra/controller/ItemController.java
@@ -13,6 +13,7 @@ import com.comatching.common.domain.enums.MemberRole;
 import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.response.ApiResponse;
 import com.comatching.common.dto.item.AddItemRequest;
+import com.comatching.common.dto.response.PagingResponse;
 import com.comatching.item.domain.dto.ItemHistoryResponse;
 import com.comatching.common.domain.enums.ItemType;
 import com.comatching.item.domain.dto.ItemResponse;
@@ -50,23 +51,23 @@ public class ItemController {
 	}
 
 	@GetMapping("/items")
-	public ResponseEntity<ApiResponse<Page<ItemResponse>>> getMyItems(
+	public ResponseEntity<ApiResponse<PagingResponse<ItemResponse>>> getMyItems(
 		@RequestHeader("X-Member-Id") Long memberId,
 		@RequestParam(required = false) ItemType type,
 		@PageableDefault(size = 10, sort = "expiredAt", direction = Sort.Direction.ASC) Pageable pageable
 	) {
-		Page<ItemResponse> result = itemService.getMyItems(memberId, type, pageable);
+		PagingResponse<ItemResponse> result = itemService.getMyItems(memberId, type, pageable);
 		return ResponseEntity.ok(ApiResponse.ok(result));
 	}
 
 	@GetMapping("/items/history")
-	public ResponseEntity<ApiResponse<Page<ItemHistoryResponse>>> getMyHistory(
+	public ResponseEntity<ApiResponse<PagingResponse<ItemHistoryResponse>>> getMyHistory(
 		@RequestHeader("X-Member-Id") Long memberId,
 		@RequestParam(required = false) ItemType type,
 		@RequestParam(required = false) ItemHistoryType historyType,
 		@PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		Page<ItemHistoryResponse> result = itemHistoryService.searchMyHistory(memberId, type, historyType, pageable);
+		PagingResponse<ItemHistoryResponse> result = itemHistoryService.searchMyHistory(memberId, type, historyType, pageable);
 		return ResponseEntity.ok(ApiResponse.ok(result));
 	}
 }

--- a/item-service/src/main/resources/application.yml
+++ b/item-service/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 9005
+  port: 9006
 
 member-service:
   url: http://localhost:9002

--- a/matching-service/src/main/java/com/comatching/matching/domain/dto/MatchingResponse.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/dto/MatchingResponse.java
@@ -24,7 +24,7 @@ public record MatchingResponse(
 	String profileImageUrl,
 	SocialAccountType socialType,
 	String socialAccountId,
-	Set<Hobby> hobbies,
+	List<Hobby> hobbies,
 	List<ProfileIntroDto> intros
 ) {
 	public static MatchingResponse of(MatchingCandidate candidate, ProfileResponse profile) {

--- a/matching-service/src/main/resources/application.yml
+++ b/matching-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ member-service:
   url: http://localhost:9002
 
 item-service:
-  url: http://localhost:9005
+  url: http://localhost:9006
 
 
 spring:

--- a/member-service/src/main/java/com/comatching/member/global/init/MemberDummyDataInitializer.java
+++ b/member-service/src/main/java/com/comatching/member/global/init/MemberDummyDataInitializer.java
@@ -66,7 +66,7 @@ public class MemberDummyDataInitializer {
 		// 1. [내 계정] 테스트용 내 계정 생성 (로그인용)
 		createMemberAndProfile(
 			"myuser@test.com", "승환", Gender.MALE, "ENFP", "컴퓨터공학과",
-			Set.of(Hobby.CODING, Hobby.SOCCER), LocalDate.of(2000, 1, 1)
+			List.of(Hobby.CODING, Hobby.SOCCER), LocalDate.of(2000, 1, 1)
 		);
 
 		// 2. [랜덤 유저] 생성
@@ -76,7 +76,7 @@ public class MemberDummyDataInitializer {
 			String major = majors.get(random.nextInt(majors.size()));
 
 			// 취미 랜덤
-			Set<Hobby> hobbies = new HashSet<>();
+			List<Hobby> hobbies = new ArrayList<>();
 			hobbies.add(Hobby.values()[random.nextInt(Hobby.values().length)]);
 
 			createMemberAndProfile(
@@ -89,19 +89,19 @@ public class MemberDummyDataInitializer {
 		// - Scenario 1: 완전 일치 (여성, ENFP, 시각디자인과, 헬스)
 		createMemberAndProfile(
 			"target1@test.com", "완벽매칭녀", Gender.FEMALE, "ENFP", "시각디자인과",
-			Set.of(Hobby.GYM), LocalDate.of(2000, 5, 5)
+			List.of(Hobby.GYM), LocalDate.of(2000, 5, 5)
 		);
 
 		// - Scenario 2: 취미만 다름 (여성, ENFP, 경영학과(전공다름), 독서(취미다름))
 		createMemberAndProfile(
 			"target2@test.com", "취미다른녀", Gender.FEMALE, "ENFP", "컴퓨터공학과",
-			Set.of(Hobby.READING), LocalDate.of(2001, 3, 15)
+			List.of(Hobby.READING), LocalDate.of(2001, 3, 15)
 		);
 
 		log.info("✅ [Member] 더미 데이터 생성 완료!");
 	}
 
-	private void createMemberAndProfile(String email, String nickname, Gender gender, String mbti, String major, Set<Hobby> hobbies, LocalDate birthDate) {
+	private void createMemberAndProfile(String email, String nickname, Gender gender, String mbti, String major, List<Hobby> hobbies, LocalDate birthDate) {
 
 		// 1. Member 생성 (USER, ACTIVE)
 		Member member = Member.builder()


### PR DESCRIPTION
- `hobbies` 필드 타입을 `Set`에서 `List`로 변경
- 공통 페이징 응답 DTO(`PagingResponse`)를 서비스 및 컨트롤러 전반에 적용
- 아이템 및 매칭 서비스 관련 로직과 테스트 코드 수정
- 게이트웨이 라우팅 및 서비스 포트 설정 업데이트