### PR TITLE
feat: 매칭 기록 즐겨찾기 기능 추가 및 관련 로직 개선

### DIFF
--- a/auth-service/src/main/java/com/comatching/auth/domain/dto/CompleteSignupResponse.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/dto/CompleteSignupResponse.java
@@ -1,0 +1,12 @@
+package com.comatching.auth.domain.dto;
+
+import com.comatching.common.dto.member.ProfileResponse;
+
+import lombok.Builder;
+
+@Builder
+public record CompleteSignupResponse(
+	ProfileResponse profile,
+	boolean isOnboardingFinished
+) {
+}

--- a/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupService.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupService.java
@@ -1,5 +1,6 @@
 package com.comatching.auth.domain.service.auth;
 
+import com.comatching.auth.domain.dto.CompleteSignupResponse;
 import com.comatching.common.dto.auth.SignupRequest;
 import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.member.ProfileCreateRequest;
@@ -13,5 +14,5 @@ public interface SignupService {
 	void signup(SignupRequest request);
 
 	// 프로필 + 토큰 갱신
-	ProfileResponse completeSignup(MemberInfo memberInfo, ProfileCreateRequest request, HttpServletResponse response);
+	CompleteSignupResponse completeSignup(MemberInfo memberInfo, ProfileCreateRequest request, HttpServletResponse response);
 }

--- a/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupServiceImpl.java
+++ b/auth-service/src/main/java/com/comatching/auth/domain/service/auth/SignupServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.comatching.auth.domain.dto.CompleteSignupResponse;
 import com.comatching.auth.domain.service.mail.EmailService;
 import com.comatching.auth.global.exception.AuthErrorCode;
 import com.comatching.auth.global.security.refresh.RefreshToken;
@@ -57,7 +58,7 @@ public class SignupServiceImpl implements SignupService {
 
 	@Override
 	@Transactional
-	public ProfileResponse completeSignup(MemberInfo memberInfo, ProfileCreateRequest request,
+	public CompleteSignupResponse completeSignup(MemberInfo memberInfo, ProfileCreateRequest request,
 		HttpServletResponse response) {
 
 		// Member Service에 프로필 생성 요청
@@ -83,6 +84,9 @@ public class SignupServiceImpl implements SignupService {
 		response.addHeader("Set-Cookie", accessCookie.toString());
 		response.addHeader("Set-Cookie", refreshCookie.toString());
 
-		return profileResponse;
+		return CompleteSignupResponse.builder()
+			.profile(profileResponse)
+			.isOnboardingFinished(false)
+			.build();
 	}
 }

--- a/auth-service/src/main/java/com/comatching/auth/infra/controller/AuthController.java
+++ b/auth-service/src/main/java/com/comatching/auth/infra/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.comatching.auth.domain.dto.ChangePasswordRequest;
+import com.comatching.auth.domain.dto.CompleteSignupResponse;
 import com.comatching.auth.domain.dto.PasswordResetCodeRequest;
 import com.comatching.auth.domain.dto.ResetPasswordRequest;
 import com.comatching.auth.domain.dto.TokenResponse;
@@ -47,13 +48,13 @@ public class AuthController {
 	}
 
 	@PostMapping("/signup/profile")
-	public ResponseEntity<ProfileResponse> completeSignup(
+	public ResponseEntity<ApiResponse<CompleteSignupResponse>> completeSignup(
 		@CurrentMember MemberInfo memberInfo,
 		@RequestBody ProfileCreateRequest request,
 		HttpServletResponse response
 	) {
-		ProfileResponse result = signupService.completeSignup(memberInfo, request, response);
-		return ResponseEntity.ok(result);
+		CompleteSignupResponse result = signupService.completeSignup(memberInfo, request, response);
+		return ResponseEntity.ok(ApiResponse.ok(result));
 	}
 
 	@PostMapping("/reissue")

--- a/auth-service/src/test/java/com/comatching/auth/domain/service/auth/SignupServiceImplTest.java
+++ b/auth-service/src/test/java/com/comatching/auth/domain/service/auth/SignupServiceImplTest.java
@@ -13,11 +13,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.comatching.auth.domain.dto.CompleteSignupResponse;
 import com.comatching.auth.domain.service.mail.EmailService;
 import com.comatching.auth.global.exception.AuthErrorCode;
 import com.comatching.auth.global.security.refresh.RefreshToken;
 import com.comatching.auth.global.security.refresh.repository.RefreshTokenRepository;
 import com.comatching.auth.infra.client.MemberServiceClient;
+import com.comatching.common.domain.enums.ContactFrequency;
 import com.comatching.common.domain.enums.Gender;
 import com.comatching.common.domain.enums.MemberRole;
 import com.comatching.common.dto.auth.SignupRequest;
@@ -94,12 +96,12 @@ class SignupServiceImplTest {
 		// given
 		Long memberId = 1L;
 		ProfileCreateRequest request = new ProfileCreateRequest(
-			"nickname", Gender.MALE, LocalDate.of(2026, 1, 6), "mbti", "intro", "imgUrl", null, null, null, null, null, null
+			"nickname", Gender.MALE, LocalDate.of(2026, 1, 6), "mbti", "intro", "imgUrl", null, null, null, null, ContactFrequency.NORMAL, null, null
 		);
 
 		ProfileResponse mockProfileResponse = new ProfileResponse(
 			memberId, "test@test.com", "nickname", Gender.MALE, LocalDate.of(2026, 1, 6), "mbti", "intro", "imgUrl",
-			null, null, null, null, null, null
+			null, null, null, null, "보통", null, null
 		);
 
 		MemberInfo memberInfo = new MemberInfo(memberId, "test@test.com", "ROLE_GUEST");
@@ -112,11 +114,11 @@ class SignupServiceImplTest {
 		given(jwtUtil.createRefreshToken(anyLong())).willReturn(refreshToken);
 
 		// when
-		ProfileResponse result = signupService.completeSignup(memberInfo, request, response);
+		CompleteSignupResponse result = signupService.completeSignup(memberInfo, request, response);
 
 		// then
-		assertThat(result.memberId()).isEqualTo(memberId);
-		assertThat(result.email()).isEqualTo("test@test.com");
+		assertThat(result.profile().memberId()).isEqualTo(memberId);
+		assertThat(result.profile().email()).isEqualTo("test@test.com");
 
 		verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
 

--- a/matching-service/src/main/java/com/comatching/matching/domain/dto/FavoriteHistoryRequest.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/dto/FavoriteHistoryRequest.java
@@ -1,0 +1,7 @@
+package com.comatching.matching.domain.dto;
+
+public record FavoriteHistoryRequest(
+	Long historyId,
+	boolean favorite
+) {
+}

--- a/matching-service/src/main/java/com/comatching/matching/domain/dto/MatchingHistoryResponse.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/dto/MatchingHistoryResponse.java
@@ -10,12 +10,14 @@ import lombok.Builder;
 public record MatchingHistoryResponse(
 	Long historyId,
 	ProfileResponse partner,
+	boolean favorite,
 	LocalDateTime matchedAt
 ) {
 	public static MatchingHistoryResponse of(MatchingHistory history, ProfileResponse partnerProfile) {
 		return MatchingHistoryResponse.builder()
 			.historyId(history.getId())
 			.partner(partnerProfile)
+			.favorite(history.isFavorite())
 			.matchedAt(history.getMatchedAt())
 			.build();
 	}

--- a/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingCandidate.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingCandidate.java
@@ -50,6 +50,7 @@ public class MatchingCandidate {
 
 	private int age;
 
+	@Enumerated(EnumType.STRING)
 	private ContactFrequency contactFrequency;
 
 	@ElementCollection(fetch = FetchType.LAZY)

--- a/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingCondition.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingCondition.java
@@ -26,18 +26,20 @@ public class MatchingCondition {
 	@Enumerated(EnumType.STRING)
 	private Hobby.Category hobbyOption;
 
-	private Boolean sameMajorOption;
+	private boolean sameMajorOption;
 
 	private String mbtiOption;
 
-	@Builder
+	private String importantOption;
 
+	@Builder
 	public MatchingCondition(AgeOption ageOption, ContactFrequency contactFrequency, Hobby.Category hobbyOption,
-		Boolean sameMajorOption, String mbtiOption) {
+		boolean sameMajorOption, String mbtiOption, String importantOption) {
 		this.ageOption = ageOption;
 		this.contactFrequency = contactFrequency;
 		this.hobbyOption = hobbyOption;
 		this.sameMajorOption = sameMajorOption;
 		this.mbtiOption = mbtiOption;
+		this.importantOption = importantOption;
 	}
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingHistory.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingHistory.java
@@ -41,6 +41,9 @@ public class MatchingHistory {
 	@Column(nullable = false)
 	private Long partnerId;
 
+	@Column(nullable = false)
+	private boolean favorite;
+
 	@Embedded
 	private MatchingCondition condition;
 
@@ -52,5 +55,10 @@ public class MatchingHistory {
 		this.memberId = memberId;
 		this.partnerId = partnerId;
 		this.condition = condition;
+		this.favorite = false;
+	}
+
+	public void updateFavorite(boolean favorite) {
+		this.favorite = favorite;
 	}
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/history/MatchingHistoryRepository.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/history/MatchingHistoryRepository.java
@@ -30,4 +30,16 @@ public interface MatchingHistoryRepository extends JpaRepository<MatchingHistory
 		@Param("endDate") LocalDateTime endDate,
 		Pageable pageable
 	);
+
+	@Query("SELECT m FROM MatchingHistory m " +
+		"WHERE m.memberId = :memberId " +
+		"AND (:startDate IS NULL OR m.matchedAt >= :startDate) " +
+		"AND (:endDate IS NULL OR m.matchedAt <= :endDate)" +
+		"AND m.favorite = TRUE")
+	Page<MatchingHistory> searchFavoriteHistory(
+		@Param("memberId") Long memberId,
+		@Param("startDate") LocalDateTime startDate,
+		@Param("endDate") LocalDateTime endDate,
+		Pageable pageable
+	);
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingHistoryService.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingHistoryService.java
@@ -1,0 +1,22 @@
+package com.comatching.matching.domain.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+
+import com.comatching.common.dto.response.PagingResponse;
+import com.comatching.matching.domain.dto.MatchingHistoryResponse;
+
+public interface MatchingHistoryService {
+
+	PagingResponse<MatchingHistoryResponse> getMyMatchingHistory(
+		Long memberId,
+		LocalDateTime startDate,
+		LocalDateTime endDate,
+		Pageable pageable,
+		boolean favoriteOnly
+	);
+
+	void changeFavorite(Long memberId, Long historyId, boolean favorite);
+
+}

--- a/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingHistoryServiceImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingHistoryServiceImpl.java
@@ -1,0 +1,83 @@
+package com.comatching.matching.domain.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.comatching.common.dto.member.ProfileResponse;
+import com.comatching.common.dto.response.PagingResponse;
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+import com.comatching.matching.domain.dto.MatchingHistoryResponse;
+import com.comatching.matching.domain.entity.MatchingHistory;
+import com.comatching.matching.domain.repository.history.MatchingHistoryRepository;
+import com.comatching.matching.global.exception.MatchingErrorCode;
+import com.comatching.matching.infra.client.MemberClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MatchingHistoryServiceImpl implements MatchingHistoryService{
+
+	private final MatchingHistoryRepository historyRepository;
+	private final MemberClient memberClient;
+
+	@Override
+	@Transactional(readOnly = true)
+	public PagingResponse<MatchingHistoryResponse> getMyMatchingHistory(
+		Long memberId,
+		LocalDateTime startDate,
+		LocalDateTime endDate,
+		Pageable pageable,
+		boolean favoriteOnly) {
+
+		Page<MatchingHistory> histories;
+
+		if (favoriteOnly) {
+			histories = historyRepository.searchFavoriteHistory(memberId, startDate, endDate, pageable);
+		}else {
+			histories = historyRepository.searchHistory(memberId, startDate, endDate, pageable);
+		}
+
+		if (histories.isEmpty()) {
+			return PagingResponse.from(Page.empty(pageable));
+		}
+
+		List<Long> partnerIds = histories.stream()
+			.map(MatchingHistory::getPartnerId)
+			.distinct()
+			.toList();
+
+		List<ProfileResponse> profiles = memberClient.getProfiles(partnerIds);
+
+		Map<Long, ProfileResponse> profileMap = profiles.stream()
+			.collect(Collectors.toMap(ProfileResponse::memberId, p -> p));
+
+		Page<MatchingHistoryResponse> resultPage = histories.map(history -> {
+			ProfileResponse partnerProfile = profileMap.get(history.getPartnerId());
+			return MatchingHistoryResponse.of(history, partnerProfile);
+		});
+
+		return PagingResponse.from(resultPage);
+	}
+
+	@Override
+	public void changeFavorite(Long memberId, Long historyId, boolean favorite) {
+		MatchingHistory matchingHistory = historyRepository.findById(historyId)
+			.orElseThrow(() -> new BusinessException(MatchingErrorCode.NOT_EXIST_HISTORY));
+
+		if (!matchingHistory.getMemberId().equals(memberId)) {
+			throw new BusinessException(GeneralErrorCode.FORBIDDEN);
+		}
+
+		matchingHistory.updateFavorite(favorite);
+	}
+}

--- a/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingService.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingService.java
@@ -1,25 +1,9 @@
 package com.comatching.matching.domain.service;
 
-import java.time.LocalDateTime;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
-import com.comatching.common.domain.enums.Gender;
-import com.comatching.common.domain.enums.Hobby;
-import com.comatching.common.dto.response.PagingResponse;
 import com.comatching.matching.domain.dto.MatchingRequest;
 import com.comatching.matching.domain.dto.MatchingResponse;
-import com.comatching.matching.domain.entity.MatchingCandidate;
-import com.comatching.matching.domain.dto.MatchingHistoryResponse;
 
 public interface MatchingService {
 
 	MatchingResponse match(Long memberId, MatchingRequest request);
-
-	PagingResponse<MatchingHistoryResponse> getMyMatchingHistory(
-		Long memberId,
-		LocalDateTime startDate,
-		LocalDateTime endDate,
-		Pageable pageable);
 }

--- a/matching-service/src/main/java/com/comatching/matching/global/exception/MatchingErrorCode.java
+++ b/matching-service/src/main/java/com/comatching/matching/global/exception/MatchingErrorCode.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public enum MatchingErrorCode implements ErrorCode {
 	NO_MATCHING_CANDIDATE("MATCH-001", HttpStatus.INTERNAL_SERVER_ERROR, "매칭 후보가 없습니다."),
 	NOT_ENOUGH_ITEM("MATCH-002", HttpStatus.BAD_REQUEST, "아이템이 부족합니다."),
+	NOT_EXIST_HISTORY("MATCH-003", HttpStatus.BAD_REQUEST, "매칭 내역이 없습니다."),
 	;
 
 	private final String code;

--- a/member-service/src/main/java/com/comatching/member/domain/entity/Profile.java
+++ b/member-service/src/main/java/com/comatching/member/domain/entity/Profile.java
@@ -62,6 +62,7 @@ public class Profile {
 	private String major;
 
 	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
 	private ContactFrequency contactFrequency;
 
 	@Column(nullable = false)


### PR DESCRIPTION
- MatchingHistory에 favorite 필드 추가 및 즐겨찾기 관리 메서드 구현
- MatchingHistoryRepository에 favorite 기준으로 검색하는 쿼리 추가
- MatchingHistoryService 분리로 좋아요 기능 및 매칭 이력 로직 개선
- MatchingController에서 즐겨찾기 API 노출
- 관련 DTO 및 테스트 코드 수정