### PR TITLE
feat(item): 상품 카탈로그 관리 변경 정리

### DIFF
--- a/item-service/build.gradle
+++ b/item-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	testRuntimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/dto/ProductCreateRequest.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/dto/ProductCreateRequest.java
@@ -4,30 +4,52 @@ import java.util.List;
 
 import com.comatching.common.domain.enums.ItemType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
+@Schema(description = "관리자 상품 등록 요청")
 public record ProductCreateRequest(
-	@NotBlank(message = "상품명은 필수입니다.")
-	String name,
+		@Schema(description = "상품명", example = "매칭권 10개 (+옵션권 5개)", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotBlank(message = "상품명은 필수입니다.")
+		String name,
 
-	@Min(value = 1, message = "가격은 1원 이상이어야 합니다.")
-	int price,
+		@Schema(description = "상품 설명. 50자 이하의 실제 설명 문구입니다.", example = "매칭권과 옵션권을 함께 충전해요.", maxLength = 50, requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotBlank(message = "상품 설명은 필수입니다.")
+		@Size(max = 50, message = "상품 설명은 50자 이하여야 합니다.")
+		String description,
 
-	boolean isActive,
+		@Schema(description = "상품 가격", example = "9000", minimum = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Min(value = 1, message = "가격은 1원 이상이어야 합니다.")
+		int price,
 
-	@NotEmpty(message = "구성품은 최소 1개 이상이어야 합니다.")
-	List<@Valid ProductRewardCreateRequest> rewards
-) {
-	public record ProductRewardCreateRequest(
-		@NotNull(message = "아이템 타입은 필수입니다.")
-		ItemType itemType,
+		@Schema(description = "상품 노출 순서. 낮을수록 먼저 노출됩니다.", example = "3", minimum = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Min(value = 0, message = "상품 노출 순서는 0 이상이어야 합니다.")
+		int displayOrder,
 
-		@Min(value = 1, message = "구성품 수량은 1 이상이어야 합니다.")
-		int quantity
+		@Schema(description = "판매 활성 여부. false이면 사용자 상품 목록과 구매 대상에서 제외됩니다.", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+		boolean isActive,
+
+		@Schema(description = "실제 지급 구성품 목록. 구매 승인 시 이 수량이 그대로 지급됩니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotEmpty(message = "구성품은 최소 1개 이상이어야 합니다.")
+		List<@Valid ProductRewardCreateRequest> rewards,
+
+		@Schema(description = "프론트 표시용 보너스 구성품 목록. 실제 지급은 rewards 기준이며, 보너스 수량은 동일 itemType의 실제 지급 수량 이하여야 합니다.")
+		List<@Valid ProductRewardCreateRequest> bonusRewards
 	) {
+		@Schema(description = "상품 구성품 또는 보너스 구성품")
+		public record ProductRewardCreateRequest(
+			@Schema(description = "아이템 타입", example = "MATCHING_TICKET", requiredMode = Schema.RequiredMode.REQUIRED)
+			@NotNull(message = "아이템 타입은 필수입니다.")
+			ItemType itemType,
+
+			@Schema(description = "수량", example = "10", minimum = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+			@Min(value = 1, message = "구성품 수량은 1 이상이어야 합니다.")
+			int quantity
+		) {
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/dto/ProductResponse.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/dto/ProductResponse.java
@@ -2,38 +2,81 @@ package com.comatching.item.domain.product.dto;
 
 import com.comatching.common.domain.enums.ItemType;
 import com.comatching.item.domain.product.entity.Product;
+import com.comatching.item.domain.product.entity.ProductBonusReward;
 import com.comatching.item.domain.product.entity.ProductReward;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "상품 응답")
 public record ProductResponse(
+	@Schema(description = "상품 ID", example = "3")
 	Long id,
+
+	@Schema(description = "상품명", example = "매칭권 10개 (+옵션권 5개)")
 	String name,
+
+	@Schema(description = "상품 설명. 50자 이하입니다.", example = "매칭권과 옵션권을 함께 충전해요.")
+	String description,
+
+	@Schema(description = "상품 가격", example = "9000")
 	int price,
-	List<ProductRewardDto> rewards
+
+	@Schema(description = "상품 노출 순서. 낮을수록 먼저 노출됩니다.", example = "3")
+	int displayOrder,
+
+	@Schema(description = "판매 활성 여부. 사용자 상품 목록은 true 상품만 반환합니다.", example = "true")
+	boolean isActive,
+
+	@Schema(description = "실제 지급 구성품 목록. 구매 승인 시 이 수량이 지급됩니다.")
+	List<ProductRewardDto> rewards,
+
+	@Schema(description = "프론트 표시용 보너스 구성품 목록. 실제 지급량은 rewards에 포함되어 있습니다.")
+	List<ProductRewardDto> bonusRewards
 ) {
 	public static ProductResponse from(Product product) {
 		return new ProductResponse(
 			product.getId(),
 			product.getName(),
+			product.getDescription(),
 			product.getPrice(),
+			product.getDisplayOrder(),
+			product.isActive(),
 			product.getRewards().stream()
+				.map(ProductRewardDto::from)
+				.toList(),
+			product.getBonusRewards().stream()
 				.map(ProductRewardDto::from)
 				.toList()
 		);
 	}
-}
 
-record ProductRewardDto(
-	ItemType itemType,
-	String itemName,
-	int quantity
-) {
-	public static ProductRewardDto from(ProductReward reward) {
-		return new ProductRewardDto(
-			reward.getItemType(),
-			reward.getItemType().getName(),
-			reward.getQuantity()
-		);
+	@Schema(description = "상품 구성품 응답")
+	public record ProductRewardDto(
+		@Schema(description = "아이템 타입", example = "OPTION_TICKET")
+		ItemType itemType,
+
+		@Schema(description = "아이템 표시명", example = "옵션권")
+		String itemName,
+
+		@Schema(description = "수량", example = "5")
+		int quantity
+	) {
+		public static ProductRewardDto from(ProductReward reward) {
+			return new ProductRewardDto(
+				reward.getItemType(),
+				reward.getItemType().getName(),
+				reward.getQuantity()
+			);
+		}
+
+		public static ProductRewardDto from(ProductBonusReward reward) {
+			return new ProductRewardDto(
+				reward.getItemType(),
+				reward.getItemType().getName(),
+				reward.getQuantity()
+			);
+		}
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/entity/Product.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/entity/Product.java
@@ -20,8 +20,14 @@ public class Product {
 	@Column(nullable = false)
 	private String name;
 
+	@Column(nullable = false, length = 50)
+	private String description;
+
 	@Column(nullable = false)
 	private int price;
+
+	@Column(nullable = false)
+	private int displayOrder;
 
 	@Column(nullable = false)
 	private boolean isActive;
@@ -29,10 +35,15 @@ public class Product {
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ProductReward> rewards = new ArrayList<>();
 
+	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<ProductBonusReward> bonusRewards = new ArrayList<>();
+
 	@Builder
-	public Product(String name, int price, boolean isActive) {
+	public Product(String name, String description, int price, int displayOrder, boolean isActive) {
 		this.name = name;
+		this.description = description;
 		this.price = price;
+		this.displayOrder = displayOrder;
 		this.isActive = isActive;
 	}
 
@@ -40,5 +51,14 @@ public class Product {
 	public void addReward(ProductReward reward) {
 		this.rewards.add(reward);
 		reward.setProduct(this);
+	}
+
+	public void addBonusReward(ProductBonusReward bonusReward) {
+		this.bonusRewards.add(bonusReward);
+		bonusReward.setProduct(this);
+	}
+
+	public void deactivate() {
+		this.isActive = false;
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/entity/ProductBonusReward.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/entity/ProductBonusReward.java
@@ -1,0 +1,49 @@
+package com.comatching.item.domain.product.entity;
+
+import com.comatching.common.domain.enums.ItemType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductBonusReward {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "product_id")
+	private Product product;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ItemType itemType;
+
+	@Column(nullable = false)
+	private int quantity;
+
+	@Builder
+	public ProductBonusReward(ItemType itemType, int quantity) {
+		this.itemType = itemType;
+		this.quantity = quantity;
+	}
+
+	protected void setProduct(Product product) {
+		this.product = product;
+	}
+}

--- a/item-service/src/main/java/com/comatching/item/domain/product/repository/ProductRepository.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/repository/ProductRepository.java
@@ -6,5 +6,7 @@ import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 	// 판매 중인 상품만 조회
-	List<Product> findByIsActiveTrue();
+	List<Product> findByIsActiveTrueOrderByDisplayOrderAscIdAsc();
+
+	List<Product> findAllByOrderByDisplayOrderAscIdAsc();
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/repository/ProductRepository.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/repository/ProductRepository.java
@@ -2,11 +2,34 @@ package com.comatching.item.domain.product.repository;
 
 import com.comatching.item.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-	// 판매 중인 상품만 조회
-	List<Product> findByIsActiveTrueOrderByDisplayOrderAscIdAsc();
 
-	List<Product> findAllByOrderByDisplayOrderAscIdAsc();
+	@Query("""
+		SELECT DISTINCT p
+		FROM Product p
+		LEFT JOIN FETCH p.rewards
+		WHERE p.isActive = true
+		ORDER BY p.displayOrder ASC, p.id ASC
+		""")
+	List<Product> findActiveProductsWithRewards();
+
+	@Query("""
+		SELECT DISTINCT p
+		FROM Product p
+		LEFT JOIN FETCH p.rewards
+		ORDER BY p.displayOrder ASC, p.id ASC
+		""")
+	List<Product> findAllProductsWithRewards();
+
+	@Query("""
+		SELECT DISTINCT p
+		FROM Product p
+		LEFT JOIN FETCH p.bonusRewards
+		WHERE p.id IN :productIds
+		""")
+	List<Product> fetchBonusRewardsByProductIds(@Param("productIds") List<Long> productIds);
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/service/AdminProductService.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/service/AdminProductService.java
@@ -1,9 +1,15 @@
 package com.comatching.item.domain.product.service;
 
+import java.util.List;
+
 import com.comatching.item.domain.product.dto.ProductCreateRequest;
 import com.comatching.item.domain.product.dto.ProductResponse;
 
 public interface AdminProductService {
 
 	ProductResponse createProduct(ProductCreateRequest request);
+
+	List<ProductResponse> getProducts();
+
+	void deleteProduct(Long productId);
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/service/AdminProductServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/service/AdminProductServiceImpl.java
@@ -1,7 +1,10 @@
 package com.comatching.item.domain.product.service;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +16,7 @@ import com.comatching.common.exception.code.GeneralErrorCode;
 import com.comatching.item.domain.product.dto.ProductCreateRequest;
 import com.comatching.item.domain.product.dto.ProductResponse;
 import com.comatching.item.domain.product.entity.Product;
+import com.comatching.item.domain.product.entity.ProductBonusReward;
 import com.comatching.item.domain.product.entity.ProductReward;
 import com.comatching.item.domain.product.repository.ProductRepository;
 
@@ -23,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class AdminProductServiceImpl implements AdminProductService {
 
+	private static final int DESCRIPTION_MAX_LENGTH = 50;
+
 	private final ProductRepository productRepository;
 
 	@Override
@@ -30,21 +36,76 @@ public class AdminProductServiceImpl implements AdminProductService {
 		if (!StringUtils.hasText(request.name())) {
 			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품명은 공백일 수 없습니다.");
 		}
+		if (!StringUtils.hasText(request.description())) {
+			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 설명은 공백일 수 없습니다.");
+		}
+		if (request.description().trim().length() > DESCRIPTION_MAX_LENGTH) {
+			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 설명은 50자 이하여야 합니다.");
+		}
 		if (request.price() <= 0) {
 			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 가격은 1원 이상이어야 합니다.");
+		}
+		if (request.displayOrder() < 0) {
+			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 노출 순서는 0 이상이어야 합니다.");
 		}
 		if (request.rewards() == null || request.rewards().isEmpty()) {
 			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 구성품은 최소 1개 이상이어야 합니다.");
 		}
 
-		Set<ItemType> duplicateCheck = new HashSet<>();
+		Map<ItemType, Integer> rewardQuantityByType = validateRewards(request.rewards());
 		Product product = Product.builder()
 			.name(request.name().trim())
+			.description(request.description().trim())
 			.price(request.price())
+			.displayOrder(request.displayOrder())
 			.isActive(request.isActive())
 			.build();
 
 		request.rewards().forEach(rewardRequest -> {
+			ProductReward reward = ProductReward.builder()
+				.itemType(rewardRequest.itemType())
+				.quantity(rewardRequest.quantity())
+				.build();
+			product.addReward(reward);
+		});
+
+		validateBonusRewards(request.bonusRewards(), rewardQuantityByType);
+		if (request.bonusRewards() != null) {
+			request.bonusRewards().forEach(bonusRewardRequest -> {
+				ProductBonusReward bonusReward = ProductBonusReward.builder()
+					.itemType(bonusRewardRequest.itemType())
+					.quantity(bonusRewardRequest.quantity())
+					.build();
+				product.addBonusReward(bonusReward);
+			});
+		}
+
+		Product saved = productRepository.save(product);
+		return ProductResponse.from(saved);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<ProductResponse> getProducts() {
+		return productRepository.findAllByOrderByDisplayOrderAscIdAsc().stream()
+			.map(ProductResponse::from)
+			.toList();
+	}
+
+	@Override
+	public void deleteProduct(Long productId) {
+		Product product = productRepository.findById(productId)
+			.orElseThrow(() -> new BusinessException(GeneralErrorCode.NOT_FOUND, "상품을 찾을 수 없습니다."));
+
+		product.deactivate();
+	}
+
+	private Map<ItemType, Integer> validateRewards(List<ProductCreateRequest.ProductRewardCreateRequest> rewards) {
+		Set<ItemType> duplicateCheck = new HashSet<>();
+		for (ProductCreateRequest.ProductRewardCreateRequest rewardRequest : rewards) {
+			if (rewardRequest.itemType() == null) {
+				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "아이템 타입은 필수입니다.");
+			}
 			if (rewardRequest.quantity() <= 0) {
 				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "구성품 수량은 1 이상이어야 합니다.");
 			}
@@ -54,15 +115,45 @@ public class AdminProductServiceImpl implements AdminProductService {
 					"동일 아이템 타입은 한 번만 등록할 수 있습니다: " + rewardRequest.itemType().name()
 				);
 			}
+		}
 
-			ProductReward reward = ProductReward.builder()
-				.itemType(rewardRequest.itemType())
-				.quantity(rewardRequest.quantity())
-				.build();
-			product.addReward(reward);
-		});
+		return rewards.stream()
+			.collect(Collectors.toMap(
+				ProductCreateRequest.ProductRewardCreateRequest::itemType,
+				ProductCreateRequest.ProductRewardCreateRequest::quantity
+			));
+	}
 
-		Product saved = productRepository.save(product);
-		return ProductResponse.from(saved);
+	private void validateBonusRewards(
+		List<ProductCreateRequest.ProductRewardCreateRequest> bonusRewards,
+		Map<ItemType, Integer> rewardQuantityByType
+	) {
+		if (bonusRewards == null || bonusRewards.isEmpty()) {
+			return;
+		}
+
+		Set<ItemType> duplicateCheck = new HashSet<>();
+		for (ProductCreateRequest.ProductRewardCreateRequest bonusReward : bonusRewards) {
+			if (bonusReward.itemType() == null) {
+				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "보너스 아이템 타입은 필수입니다.");
+			}
+			if (bonusReward.quantity() <= 0) {
+				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "보너스 수량은 1 이상이어야 합니다.");
+			}
+			if (!duplicateCheck.add(bonusReward.itemType())) {
+				throw new BusinessException(
+					GeneralErrorCode.INVALID_INPUT_VALUE,
+					"동일 보너스 아이템 타입은 한 번만 등록할 수 있습니다: " + bonusReward.itemType().name()
+				);
+			}
+
+			Integer rewardQuantity = rewardQuantityByType.get(bonusReward.itemType());
+			if (rewardQuantity == null) {
+				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "보너스는 실제 구성품에 포함된 아이템만 등록할 수 있습니다.");
+			}
+			if (bonusReward.quantity() > rewardQuantity) {
+				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "보너스 수량은 실제 지급 수량보다 클 수 없습니다.");
+			}
+		}
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/service/AdminProductServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/service/AdminProductServiceImpl.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import com.comatching.common.domain.enums.ItemType;
 import com.comatching.common.exception.BusinessException;
@@ -27,31 +26,10 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class AdminProductServiceImpl implements AdminProductService {
 
-	private static final int DESCRIPTION_MAX_LENGTH = 50;
-
 	private final ProductRepository productRepository;
 
 	@Override
 	public ProductResponse createProduct(ProductCreateRequest request) {
-		if (!StringUtils.hasText(request.name())) {
-			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품명은 공백일 수 없습니다.");
-		}
-		if (!StringUtils.hasText(request.description())) {
-			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 설명은 공백일 수 없습니다.");
-		}
-		if (request.description().trim().length() > DESCRIPTION_MAX_LENGTH) {
-			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 설명은 50자 이하여야 합니다.");
-		}
-		if (request.price() <= 0) {
-			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 가격은 1원 이상이어야 합니다.");
-		}
-		if (request.displayOrder() < 0) {
-			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 노출 순서는 0 이상이어야 합니다.");
-		}
-		if (request.rewards() == null || request.rewards().isEmpty()) {
-			throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "상품 구성품은 최소 1개 이상이어야 합니다.");
-		}
-
 		Map<ItemType, Integer> rewardQuantityByType = validateRewards(request.rewards());
 		Product product = Product.builder()
 			.name(request.name().trim())
@@ -87,7 +65,9 @@ public class AdminProductServiceImpl implements AdminProductService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<ProductResponse> getProducts() {
-		return productRepository.findAllByOrderByDisplayOrderAscIdAsc().stream()
+		List<Product> products = productRepository.findAllProductsWithRewards();
+		fetchBonusRewards(products);
+		return products.stream()
 			.map(ProductResponse::from)
 			.toList();
 	}
@@ -103,12 +83,6 @@ public class AdminProductServiceImpl implements AdminProductService {
 	private Map<ItemType, Integer> validateRewards(List<ProductCreateRequest.ProductRewardCreateRequest> rewards) {
 		Set<ItemType> duplicateCheck = new HashSet<>();
 		for (ProductCreateRequest.ProductRewardCreateRequest rewardRequest : rewards) {
-			if (rewardRequest.itemType() == null) {
-				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "아이템 타입은 필수입니다.");
-			}
-			if (rewardRequest.quantity() <= 0) {
-				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "구성품 수량은 1 이상이어야 합니다.");
-			}
 			if (!duplicateCheck.add(rewardRequest.itemType())) {
 				throw new BusinessException(
 					GeneralErrorCode.INVALID_INPUT_VALUE,
@@ -134,12 +108,6 @@ public class AdminProductServiceImpl implements AdminProductService {
 
 		Set<ItemType> duplicateCheck = new HashSet<>();
 		for (ProductCreateRequest.ProductRewardCreateRequest bonusReward : bonusRewards) {
-			if (bonusReward.itemType() == null) {
-				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "보너스 아이템 타입은 필수입니다.");
-			}
-			if (bonusReward.quantity() <= 0) {
-				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "보너스 수량은 1 이상이어야 합니다.");
-			}
 			if (!duplicateCheck.add(bonusReward.itemType())) {
 				throw new BusinessException(
 					GeneralErrorCode.INVALID_INPUT_VALUE,
@@ -155,5 +123,16 @@ public class AdminProductServiceImpl implements AdminProductService {
 				throw new BusinessException(GeneralErrorCode.INVALID_INPUT_VALUE, "보너스 수량은 실제 지급 수량보다 클 수 없습니다.");
 			}
 		}
+	}
+
+	private void fetchBonusRewards(List<Product> products) {
+		if (products.isEmpty()) {
+			return;
+		}
+
+		List<Long> productIds = products.stream()
+			.map(Product::getId)
+			.toList();
+		productRepository.fetchBonusRewardsByProductIds(productIds);
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/service/ShopServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/service/ShopServiceImpl.java
@@ -39,7 +39,9 @@ public class ShopServiceImpl implements ShopService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<ProductResponse> getActiveProducts() {
-		return productRepository.findByIsActiveTrueOrderByDisplayOrderAscIdAsc().stream()
+		List<Product> products = productRepository.findActiveProductsWithRewards();
+		fetchBonusRewards(products);
+		return products.stream()
 			.map(ProductResponse::from)
 			.toList();
 	}
@@ -98,5 +100,16 @@ public class ShopServiceImpl implements ShopService {
 			throw new BusinessException(errorCode);
 		}
 		return value.trim();
+	}
+
+	private void fetchBonusRewards(List<Product> products) {
+		if (products.isEmpty()) {
+			return;
+		}
+
+		List<Long> productIds = products.stream()
+			.map(Product::getId)
+			.toList();
+		productRepository.fetchBonusRewardsByProductIds(productIds);
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/service/ShopServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/service/ShopServiceImpl.java
@@ -39,7 +39,7 @@ public class ShopServiceImpl implements ShopService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<ProductResponse> getActiveProducts() {
-		return productRepository.findByIsActiveTrue().stream()
+		return productRepository.findByIsActiveTrueOrderByDisplayOrderAscIdAsc().stream()
 			.map(ProductResponse::from)
 			.toList();
 	}

--- a/item-service/src/main/java/com/comatching/item/global/init/ShopDataInitializer.java
+++ b/item-service/src/main/java/com/comatching/item/global/init/ShopDataInitializer.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.comatching.common.domain.enums.ItemType;
 import com.comatching.item.domain.product.entity.Product;
+import com.comatching.item.domain.product.entity.ProductBonusReward;
 import com.comatching.item.domain.product.entity.ProductReward;
 import com.comatching.item.domain.product.repository.ProductRepository;
 
@@ -34,7 +35,9 @@ public class ShopDataInitializer implements CommandLineRunner {
 		// 1. 뽑기권 X1 (1,000원)
 		Product p1 = Product.builder()
 			.name("매칭권 1개")
+			.description("기본 매칭을 1회 이용할 수 있어요.")
 			.price(1000)
+			.displayOrder(1)
 			.isActive(true)
 			.build();
 		p1.addReward(ProductReward.builder()
@@ -45,7 +48,9 @@ public class ShopDataInitializer implements CommandLineRunner {
 		// 2. 뽑기권 X5 + 옵션권 X1 (5,000원)
 		Product p2 = Product.builder()
 			.name("매칭권 5개 (+옵션권 1개)")
+			.description("매칭권 5개와 옵션권 1개 패키지예요.")
 			.price(5000)
+			.displayOrder(2)
 			.isActive(true)
 			.build();
 		p2.addReward(ProductReward.builder()
@@ -56,11 +61,17 @@ public class ShopDataInitializer implements CommandLineRunner {
 			.itemType(ItemType.OPTION_TICKET)
 			.quantity(1)
 			.build());
+		p2.addBonusReward(ProductBonusReward.builder()
+			.itemType(ItemType.OPTION_TICKET)
+			.quantity(1)
+			.build());
 
 		// 3. 뽑기권 X10 (9,000원) - 할인 상품
 		Product p3 = Product.builder()
 			.name("매칭권 10개 (10% 할인)")
+			.description("매칭권 10개를 할인된 가격으로 충전해요.")
 			.price(9000)
+			.displayOrder(3)
 			.isActive(true)
 			.build();
 		p3.addReward(ProductReward.builder()
@@ -71,7 +82,9 @@ public class ShopDataInitializer implements CommandLineRunner {
 		// 4. 옵션권 X1 (300원)
 		Product p4 = Product.builder()
 			.name("옵션권 1개")
+			.description("중요 조건 옵션을 1회 사용할 수 있어요.")
 			.price(300)
+			.displayOrder(4)
 			.isActive(true)
 			.build();
 		p4.addReward(ProductReward.builder()

--- a/item-service/src/main/java/com/comatching/item/infra/controller/AdminProductController.java
+++ b/item-service/src/main/java/com/comatching/item/infra/controller/AdminProductController.java
@@ -1,6 +1,11 @@
 package com.comatching.item.infra.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +25,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "Admin Product API", description = "관리자 전용 상품 등록")
+@Tag(name = "Admin Product API", description = "관리자 전용 상품 관리")
 @RestController
 @RequestMapping("/api/v1/admin/shop")
 @RequiredArgsConstructor
@@ -29,7 +34,10 @@ public class AdminProductController {
 	private final AdminProductService adminProductService;
 
 	@RequireRole(MemberRole.ROLE_ADMIN)
-	@Operation(summary = "상품 등록", description = "상품명/가격/활성여부/구성품을 입력받아 신규 상품을 등록합니다.")
+	@Operation(
+		summary = "상품 등록",
+		description = "상품명, 50자 이하 설명, 가격, 노출 순서, 활성 여부, 실제 지급 구성품, 프론트 표시용 보너스 구성품을 입력받아 신규 상품을 등록합니다. 실제 지급은 rewards 기준이며 bonusRewards는 표시용입니다."
+	)
 	@PostMapping("/products")
 	public ResponseEntity<ApiResponse<ProductResponse>> createProduct(
 		@CurrentMember MemberInfo memberInfo,
@@ -37,5 +45,28 @@ public class AdminProductController {
 	) {
 		ProductResponse response = adminProductService.createProduct(request);
 		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@RequireRole(MemberRole.ROLE_ADMIN)
+	@Operation(
+		summary = "관리자 상품 목록 조회",
+		description = "활성/비활성 전체 상품 목록을 displayOrder 오름차순, id 오름차순으로 조회합니다."
+	)
+	@GetMapping("/products")
+	public ResponseEntity<ApiResponse<List<ProductResponse>>> getProducts(
+		@CurrentMember MemberInfo memberInfo
+	) {
+		return ResponseEntity.ok(ApiResponse.ok(adminProductService.getProducts()));
+	}
+
+	@RequireRole(MemberRole.ROLE_ADMIN)
+	@Operation(summary = "상품 삭제", description = "상품을 실제 삭제하지 않고 isActive=false로 변경하여 판매 중지 처리합니다.")
+	@DeleteMapping("/products/{productId}")
+	public ResponseEntity<ApiResponse<Void>> deleteProduct(
+		@CurrentMember MemberInfo memberInfo,
+		@PathVariable Long productId
+	) {
+		adminProductService.deleteProduct(productId);
+		return ResponseEntity.ok(ApiResponse.ok());
 	}
 }

--- a/item-service/src/main/java/com/comatching/item/infra/controller/ShopController.java
+++ b/item-service/src/main/java/com/comatching/item/infra/controller/ShopController.java
@@ -28,7 +28,10 @@ public class ShopController {
 
 	private final ShopService shopService;
 
-	@Operation(summary = "상품 목록 조회", description = "현재 판매 중인 모든 아이템 패키지 목록을 조회합니다.")
+	@Operation(
+		summary = "상품 목록 조회",
+		description = "현재 판매 중인 활성 상품만 displayOrder 오름차순, id 오름차순으로 조회합니다. 응답에는 실제 지급 rewards와 프론트 표시용 bonusRewards가 함께 포함됩니다."
+	)
 	@GetMapping("/products")
 	public ResponseEntity<ApiResponse<List<ProductResponse>>> getActiveProducts() {
 		return ResponseEntity.ok(ApiResponse.ok(shopService.getActiveProducts()));

--- a/item-service/src/test/java/com/comatching/item/domain/product/dto/ProductCreateRequestTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/product/dto/ProductCreateRequestTest.java
@@ -1,0 +1,149 @@
+package com.comatching.item.domain.product.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.comatching.common.domain.enums.ItemType;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+@DisplayName("ProductCreateRequest 검증 테스트")
+class ProductCreateRequestTest {
+
+	private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("invalidRequests")
+	@DisplayName("상품 생성 요청의 Bean Validation 제약을 검증한다")
+	void shouldValidateProductCreateRequest(String name, ProductCreateRequest request, String expectedMessage) {
+		// when
+		Set<ConstraintViolation<ProductCreateRequest>> violations = validator.validate(request);
+
+		// then
+		assertThat(violations).extracting(ConstraintViolation::getMessage)
+			.contains(expectedMessage);
+	}
+
+	@Test
+	@DisplayName("보너스 구성품은 생략할 수 있다")
+	void shouldAllowNullBonusRewards() {
+		// given
+		ProductCreateRequest request = new ProductCreateRequest(
+			"신규 번들",
+			"상품 설명",
+			1000,
+			1,
+			true,
+			List.of(reward(ItemType.MATCHING_TICKET, 1)),
+			null
+		);
+
+		// when
+		Set<ConstraintViolation<ProductCreateRequest>> violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	private static Stream<Arguments> invalidRequests() {
+		return Stream.of(
+			Arguments.of(
+				"상품명 공백",
+				request(" ", "상품 설명", 1000, 1, List.of(reward(ItemType.MATCHING_TICKET, 1)), List.of()),
+				"상품명은 필수입니다."
+			),
+			Arguments.of(
+				"상품 설명 공백",
+				request("신규 번들", " ", 1000, 1, List.of(reward(ItemType.MATCHING_TICKET, 1)), List.of()),
+				"상품 설명은 필수입니다."
+			),
+			Arguments.of(
+				"상품 설명 길이 초과",
+				request(
+					"신규 번들",
+					"123456789012345678901234567890123456789012345678901",
+					1000,
+					1,
+					List.of(reward(ItemType.MATCHING_TICKET, 1)),
+					List.of()
+				),
+				"상품 설명은 50자 이하여야 합니다."
+			),
+			Arguments.of(
+				"가격 최소값",
+				request("신규 번들", "상품 설명", 0, 1, List.of(reward(ItemType.MATCHING_TICKET, 1)), List.of()),
+				"가격은 1원 이상이어야 합니다."
+			),
+			Arguments.of(
+				"노출 순서 최소값",
+				request("신규 번들", "상품 설명", 1000, -1, List.of(reward(ItemType.MATCHING_TICKET, 1)), List.of()),
+				"상품 노출 순서는 0 이상이어야 합니다."
+			),
+			Arguments.of(
+				"구성품 필수",
+				request("신규 번들", "상품 설명", 1000, 1, List.of(), List.of()),
+				"구성품은 최소 1개 이상이어야 합니다."
+			),
+			Arguments.of(
+				"구성품 아이템 타입 필수",
+				request("신규 번들", "상품 설명", 1000, 1, List.of(reward(null, 1)), List.of()),
+				"아이템 타입은 필수입니다."
+			),
+			Arguments.of(
+				"구성품 수량 최소값",
+				request("신규 번들", "상품 설명", 1000, 1, List.of(reward(ItemType.MATCHING_TICKET, 0)), List.of()),
+				"구성품 수량은 1 이상이어야 합니다."
+			),
+			Arguments.of(
+				"보너스 아이템 타입 필수",
+				request(
+					"신규 번들",
+					"상품 설명",
+					1000,
+					1,
+					List.of(reward(ItemType.MATCHING_TICKET, 1)),
+					List.of(reward(null, 1))
+				),
+				"아이템 타입은 필수입니다."
+			),
+			Arguments.of(
+				"보너스 수량 최소값",
+				request(
+					"신규 번들",
+					"상품 설명",
+					1000,
+					1,
+					List.of(reward(ItemType.MATCHING_TICKET, 1)),
+					List.of(reward(ItemType.MATCHING_TICKET, 0))
+				),
+				"구성품 수량은 1 이상이어야 합니다."
+			)
+		);
+	}
+
+	private static ProductCreateRequest request(
+		String name,
+		String description,
+		int price,
+		int displayOrder,
+		List<ProductCreateRequest.ProductRewardCreateRequest> rewards,
+		List<ProductCreateRequest.ProductRewardCreateRequest> bonusRewards
+	) {
+		return new ProductCreateRequest(name, description, price, displayOrder, true, rewards, bonusRewards);
+	}
+
+	private static ProductCreateRequest.ProductRewardCreateRequest reward(ItemType itemType, int quantity) {
+		return new ProductCreateRequest.ProductRewardCreateRequest(itemType, quantity);
+	}
+}

--- a/item-service/src/test/java/com/comatching/item/domain/product/repository/ProductRepositoryTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/product/repository/ProductRepositoryTest.java
@@ -1,0 +1,128 @@
+package com.comatching.item.domain.product.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.comatching.common.domain.enums.ItemType;
+import com.comatching.item.domain.product.entity.Product;
+import com.comatching.item.domain.product.entity.ProductBonusReward;
+import com.comatching.item.domain.product.entity.ProductReward;
+
+@DataJpaTest
+@ContextConfiguration(classes = ProductRepositoryTest.JpaTestConfig.class)
+@DisplayName("ProductRepository 테스트")
+class ProductRepositoryTest {
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Test
+	@DisplayName("활성 상품은 rewards와 bonusRewards를 N+1 없이 단계적으로 조회한다")
+	void shouldFetchActiveProductsWithRewardsAndBonusRewards() {
+		// given
+		Product second = product("두 번째 상품", 2, true);
+		second.addReward(reward(ItemType.MATCHING_TICKET, 1));
+		second.addBonusReward(bonusReward(ItemType.MATCHING_TICKET, 1));
+
+		Product first = product("첫 번째 상품", 1, true);
+		first.addReward(reward(ItemType.MATCHING_TICKET, 2));
+		first.addReward(reward(ItemType.OPTION_TICKET, 1));
+		first.addBonusReward(bonusReward(ItemType.OPTION_TICKET, 1));
+
+		Product inactive = product("비활성 상품", 3, false);
+		inactive.addReward(reward(ItemType.MATCHING_TICKET, 1));
+
+		entityManager.persist(second);
+		entityManager.persist(first);
+		entityManager.persist(inactive);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		List<Product> products = productRepository.findActiveProductsWithRewards();
+		productRepository.fetchBonusRewardsByProductIds(products.stream().map(Product::getId).toList());
+
+		// then
+		assertThat(products).extracting(Product::getName).containsExactly("첫 번째 상품", "두 번째 상품");
+		assertThat(products).allSatisfy(product -> {
+			assertThat(Hibernate.isInitialized(product.getRewards())).isTrue();
+			assertThat(Hibernate.isInitialized(product.getBonusRewards())).isTrue();
+		});
+		assertThat(products.get(0).getRewards()).hasSize(2);
+		assertThat(products.get(0).getBonusRewards()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("관리자 상품 목록은 비활성 상품까지 정렬하여 조회한다")
+	void shouldFetchAllProductsOrdered() {
+		// given
+		Product inactive = product("비활성 상품", 2, false);
+		inactive.addReward(reward(ItemType.MATCHING_TICKET, 1));
+
+		Product active = product("활성 상품", 1, true);
+		active.addReward(reward(ItemType.MATCHING_TICKET, 1));
+
+		entityManager.persist(inactive);
+		entityManager.persist(active);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		List<Product> products = productRepository.findAllProductsWithRewards();
+		productRepository.fetchBonusRewardsByProductIds(products.stream().map(Product::getId).toList());
+
+		// then
+		assertThat(products).extracting(Product::getName).containsExactly("활성 상품", "비활성 상품");
+		assertThat(products).allSatisfy(product -> {
+			assertThat(Hibernate.isInitialized(product.getRewards())).isTrue();
+			assertThat(Hibernate.isInitialized(product.getBonusRewards())).isTrue();
+		});
+	}
+
+	private Product product(String name, int displayOrder, boolean isActive) {
+		return Product.builder()
+			.name(name)
+			.description("상품 설명")
+			.price(1000)
+			.displayOrder(displayOrder)
+			.isActive(isActive)
+			.build();
+	}
+
+	private ProductReward reward(ItemType itemType, int quantity) {
+		return ProductReward.builder()
+			.itemType(itemType)
+			.quantity(quantity)
+			.build();
+	}
+
+	private ProductBonusReward bonusReward(ItemType itemType, int quantity) {
+		return ProductBonusReward.builder()
+			.itemType(itemType)
+			.quantity(quantity)
+			.build();
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	@EntityScan(basePackageClasses = Product.class)
+	@EnableJpaRepositories(basePackageClasses = ProductRepository.class)
+	static class JpaTestConfig {
+	}
+}

--- a/item-service/src/test/java/com/comatching/item/domain/product/service/AdminProductServiceImplTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/product/service/AdminProductServiceImplTest.java
@@ -92,7 +92,7 @@ class AdminProductServiceImplTest {
 		ReflectionTestUtils.setField(active, "id", 1L);
 		ReflectionTestUtils.setField(inactive, "id", 2L);
 
-		given(productRepository.findAllByOrderByDisplayOrderAscIdAsc()).willReturn(List.of(active, inactive));
+		given(productRepository.findAllProductsWithRewards()).willReturn(List.of(active, inactive));
 
 		// when
 		List<ProductResponse> responses = adminProductService.getProducts();
@@ -100,6 +100,7 @@ class AdminProductServiceImplTest {
 		// then
 		assertThat(responses).extracting(ProductResponse::id).containsExactly(1L, 2L);
 		assertThat(responses).extracting(ProductResponse::isActive).containsExactly(true, false);
+		then(productRepository).should().fetchBonusRewardsByProductIds(List.of(1L, 2L));
 	}
 
 	@Test
@@ -135,70 +136,6 @@ class AdminProductServiceImplTest {
 		// given
 		ProductCreateRequest request = request(
 			List.of(reward(ItemType.MATCHING_TICKET, 1), reward(ItemType.MATCHING_TICKET, 2)),
-			List.of()
-		);
-
-		// when & then
-		assertInvalidInput(request);
-	}
-
-	@Test
-	@DisplayName("구성품이 비어있으면 예외가 발생한다")
-	void shouldThrowWhenRewardsEmpty() {
-		// given
-		ProductCreateRequest request = request(List.of(), List.of());
-
-		// when & then
-		assertInvalidInput(request);
-	}
-
-	@Test
-	@DisplayName("상품 설명이 공백이면 예외가 발생한다")
-	void shouldThrowWhenDescriptionBlank() {
-		// given
-		ProductCreateRequest request = new ProductCreateRequest(
-			"신규 번들",
-			" ",
-			1000,
-			1,
-			true,
-			List.of(reward(ItemType.MATCHING_TICKET, 1)),
-			List.of()
-		);
-
-		// when & then
-		assertInvalidInput(request);
-	}
-
-	@Test
-	@DisplayName("상품 설명이 50자를 초과하면 예외가 발생한다")
-	void shouldThrowWhenDescriptionTooLong() {
-		// given
-		ProductCreateRequest request = new ProductCreateRequest(
-			"신규 번들",
-			"123456789012345678901234567890123456789012345678901",
-			1000,
-			1,
-			true,
-			List.of(reward(ItemType.MATCHING_TICKET, 1)),
-			List.of()
-		);
-
-		// when & then
-		assertInvalidInput(request);
-	}
-
-	@Test
-	@DisplayName("상품 노출 순서가 음수이면 예외가 발생한다")
-	void shouldThrowWhenDisplayOrderNegative() {
-		// given
-		ProductCreateRequest request = new ProductCreateRequest(
-			"신규 번들",
-			"상품 설명",
-			1000,
-			-1,
-			true,
-			List.of(reward(ItemType.MATCHING_TICKET, 1)),
 			List.of()
 		);
 

--- a/item-service/src/test/java/com/comatching/item/domain/product/service/AdminProductServiceImplTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/product/service/AdminProductServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.comatching.common.domain.enums.ItemType;
 import com.comatching.common.exception.BusinessException;
@@ -22,6 +24,8 @@ import com.comatching.common.exception.code.GeneralErrorCode;
 import com.comatching.item.domain.product.dto.ProductCreateRequest;
 import com.comatching.item.domain.product.dto.ProductResponse;
 import com.comatching.item.domain.product.entity.Product;
+import com.comatching.item.domain.product.entity.ProductBonusReward;
+import com.comatching.item.domain.product.entity.ProductReward;
 import com.comatching.item.domain.product.repository.ProductRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,17 +39,20 @@ class AdminProductServiceImplTest {
 	private ProductRepository productRepository;
 
 	@Test
-	@DisplayName("상품과 구성품을 등록하면 ProductResponse를 반환한다")
+	@DisplayName("상품과 구성품, 보너스 구성품을 등록하면 ProductResponse를 반환한다")
 	void shouldCreateProduct() {
 		// given
 		ProductCreateRequest request = new ProductCreateRequest(
 			"신규 번들",
+			"매칭권과 옵션권을 함께 충전해요.",
 			3300,
+			7,
 			true,
 			List.of(
-				new ProductCreateRequest.ProductRewardCreateRequest(ItemType.MATCHING_TICKET, 3),
-				new ProductCreateRequest.ProductRewardCreateRequest(ItemType.OPTION_TICKET, 1)
-			)
+				reward(ItemType.MATCHING_TICKET, 3),
+				reward(ItemType.OPTION_TICKET, 1)
+			),
+			List.of(reward(ItemType.OPTION_TICKET, 1))
 		);
 
 		given(productRepository.save(any(Product.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -59,49 +66,213 @@ class AdminProductServiceImplTest {
 		Product saved = productCaptor.getValue();
 
 		assertThat(saved.getName()).isEqualTo("신규 번들");
+		assertThat(saved.getDescription()).isEqualTo("매칭권과 옵션권을 함께 충전해요.");
 		assertThat(saved.getPrice()).isEqualTo(3300);
+		assertThat(saved.getDisplayOrder()).isEqualTo(7);
+		assertThat(saved.isActive()).isTrue();
 		assertThat(saved.getRewards()).hasSize(2);
+		assertThat(saved.getBonusRewards()).hasSize(1);
 		assertThat(response.name()).isEqualTo("신규 번들");
+		assertThat(response.description()).isEqualTo("매칭권과 옵션권을 함께 충전해요.");
 		assertThat(response.price()).isEqualTo(3300);
+		assertThat(response.displayOrder()).isEqualTo(7);
+		assertThat(response.isActive()).isTrue();
 		assertThat(response.rewards()).hasSize(2);
+		assertThat(response.bonusRewards()).hasSize(1);
+		assertThat(response.bonusRewards().get(0).itemType()).isEqualTo(ItemType.OPTION_TICKET);
+		assertThat(response.bonusRewards().get(0).quantity()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("관리자 상품 목록은 비활성 상품도 포함한다")
+	void shouldGetAllProductsForAdmin() {
+		// given
+		Product active = product("활성 상품", "활성 설명", 1000, 1, true);
+		Product inactive = product("비활성 상품", "비활성 설명", 2000, 2, false);
+		ReflectionTestUtils.setField(active, "id", 1L);
+		ReflectionTestUtils.setField(inactive, "id", 2L);
+
+		given(productRepository.findAllByOrderByDisplayOrderAscIdAsc()).willReturn(List.of(active, inactive));
+
+		// when
+		List<ProductResponse> responses = adminProductService.getProducts();
+
+		// then
+		assertThat(responses).extracting(ProductResponse::id).containsExactly(1L, 2L);
+		assertThat(responses).extracting(ProductResponse::isActive).containsExactly(true, false);
+	}
+
+	@Test
+	@DisplayName("상품 삭제는 실제 삭제가 아니라 비활성화한다")
+	void shouldDeactivateProductWhenDeleted() {
+		// given
+		Product product = product("판매 상품", "판매 설명", 1000, 1, true);
+		given(productRepository.findById(1L)).willReturn(Optional.of(product));
+
+		// when
+		adminProductService.deleteProduct(1L);
+
+		// then
+		assertThat(product.isActive()).isFalse();
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 상품을 삭제하면 404 예외가 발생한다")
+	void shouldThrowWhenDeleteProductNotFound() {
+		// given
+		given(productRepository.findById(999L)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> adminProductService.deleteProduct(999L))
+			.isInstanceOf(BusinessException.class)
+			.extracting(exception -> ((BusinessException)exception).getErrorCode())
+			.isEqualTo(GeneralErrorCode.NOT_FOUND);
 	}
 
 	@Test
 	@DisplayName("동일 itemType을 중복 등록하면 예외가 발생한다")
 	void shouldThrowWhenRewardTypeDuplicated() {
 		// given
-		ProductCreateRequest request = new ProductCreateRequest(
-			"중복 번들",
-			1000,
-			true,
-			List.of(
-				new ProductCreateRequest.ProductRewardCreateRequest(ItemType.MATCHING_TICKET, 1),
-				new ProductCreateRequest.ProductRewardCreateRequest(ItemType.MATCHING_TICKET, 2)
-			)
+		ProductCreateRequest request = request(
+			List.of(reward(ItemType.MATCHING_TICKET, 1), reward(ItemType.MATCHING_TICKET, 2)),
+			List.of()
 		);
 
 		// when & then
-		assertThatThrownBy(() -> adminProductService.createProduct(request))
-			.isInstanceOf(BusinessException.class)
-			.extracting(exception -> ((BusinessException)exception).getErrorCode())
-			.isEqualTo(GeneralErrorCode.INVALID_INPUT_VALUE);
+		assertInvalidInput(request);
 	}
 
 	@Test
 	@DisplayName("구성품이 비어있으면 예외가 발생한다")
 	void shouldThrowWhenRewardsEmpty() {
 		// given
+		ProductCreateRequest request = request(List.of(), List.of());
+
+		// when & then
+		assertInvalidInput(request);
+	}
+
+	@Test
+	@DisplayName("상품 설명이 공백이면 예외가 발생한다")
+	void shouldThrowWhenDescriptionBlank() {
+		// given
 		ProductCreateRequest request = new ProductCreateRequest(
-			"빈 번들",
+			"신규 번들",
+			" ",
 			1000,
+			1,
 			true,
+			List.of(reward(ItemType.MATCHING_TICKET, 1)),
 			List.of()
 		);
 
 		// when & then
+		assertInvalidInput(request);
+	}
+
+	@Test
+	@DisplayName("상품 설명이 50자를 초과하면 예외가 발생한다")
+	void shouldThrowWhenDescriptionTooLong() {
+		// given
+		ProductCreateRequest request = new ProductCreateRequest(
+			"신규 번들",
+			"123456789012345678901234567890123456789012345678901",
+			1000,
+			1,
+			true,
+			List.of(reward(ItemType.MATCHING_TICKET, 1)),
+			List.of()
+		);
+
+		// when & then
+		assertInvalidInput(request);
+	}
+
+	@Test
+	@DisplayName("상품 노출 순서가 음수이면 예외가 발생한다")
+	void shouldThrowWhenDisplayOrderNegative() {
+		// given
+		ProductCreateRequest request = new ProductCreateRequest(
+			"신규 번들",
+			"상품 설명",
+			1000,
+			-1,
+			true,
+			List.of(reward(ItemType.MATCHING_TICKET, 1)),
+			List.of()
+		);
+
+		// when & then
+		assertInvalidInput(request);
+	}
+
+	@Test
+	@DisplayName("보너스 itemType을 중복 등록하면 예외가 발생한다")
+	void shouldThrowWhenBonusRewardTypeDuplicated() {
+		// given
+		ProductCreateRequest request = request(
+			List.of(reward(ItemType.MATCHING_TICKET, 3)),
+			List.of(reward(ItemType.MATCHING_TICKET, 1), reward(ItemType.MATCHING_TICKET, 1))
+		);
+
+		// when & then
+		assertInvalidInput(request);
+	}
+
+	@Test
+	@DisplayName("보너스가 실제 구성품에 없는 itemType이면 예외가 발생한다")
+	void shouldThrowWhenBonusRewardTypeNotInRewards() {
+		// given
+		ProductCreateRequest request = request(
+			List.of(reward(ItemType.MATCHING_TICKET, 3)),
+			List.of(reward(ItemType.OPTION_TICKET, 1))
+		);
+
+		// when & then
+		assertInvalidInput(request);
+	}
+
+	@Test
+	@DisplayName("보너스 수량이 실제 지급 수량보다 크면 예외가 발생한다")
+	void shouldThrowWhenBonusRewardQuantityExceedsRewardQuantity() {
+		// given
+		ProductCreateRequest request = request(
+			List.of(reward(ItemType.MATCHING_TICKET, 3)),
+			List.of(reward(ItemType.MATCHING_TICKET, 4))
+		);
+
+		// when & then
+		assertInvalidInput(request);
+	}
+
+	private void assertInvalidInput(ProductCreateRequest request) {
 		assertThatThrownBy(() -> adminProductService.createProduct(request))
 			.isInstanceOf(BusinessException.class)
 			.extracting(exception -> ((BusinessException)exception).getErrorCode())
 			.isEqualTo(GeneralErrorCode.INVALID_INPUT_VALUE);
+	}
+
+	private ProductCreateRequest request(
+		List<ProductCreateRequest.ProductRewardCreateRequest> rewards,
+		List<ProductCreateRequest.ProductRewardCreateRequest> bonusRewards
+	) {
+		return new ProductCreateRequest("신규 번들", "상품 설명", 1000, 1, true, rewards, bonusRewards);
+	}
+
+	private ProductCreateRequest.ProductRewardCreateRequest reward(ItemType itemType, int quantity) {
+		return new ProductCreateRequest.ProductRewardCreateRequest(itemType, quantity);
+	}
+
+	private Product product(String name, String description, int price, int displayOrder, boolean isActive) {
+		Product product = Product.builder()
+			.name(name)
+			.description(description)
+			.price(price)
+			.displayOrder(displayOrder)
+			.isActive(isActive)
+			.build();
+		product.addReward(ProductReward.builder().itemType(ItemType.MATCHING_TICKET).quantity(1).build());
+		product.addBonusReward(ProductBonusReward.builder().itemType(ItemType.MATCHING_TICKET).quantity(1).build());
+		return product;
 	}
 }

--- a/item-service/src/test/java/com/comatching/item/domain/product/service/ShopServiceImplTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/product/service/ShopServiceImplTest.java
@@ -103,7 +103,7 @@ class ShopServiceImplTest {
 		Product second = product("두 번째 상품", 2000, true);
 		ReflectionTestUtils.setField(first, "id", 1L);
 		ReflectionTestUtils.setField(second, "id", 2L);
-		given(productRepository.findByIsActiveTrueOrderByDisplayOrderAscIdAsc()).willReturn(List.of(first, second));
+		given(productRepository.findActiveProductsWithRewards()).willReturn(List.of(first, second));
 
 		// when
 		List<ProductResponse> responses = shopService.getActiveProducts();
@@ -111,6 +111,7 @@ class ShopServiceImplTest {
 		// then
 		assertThat(responses).extracting(ProductResponse::id).containsExactly(1L, 2L);
 		assertThat(responses).extracting(ProductResponse::isActive).containsExactly(true, true);
+		then(productRepository).should().fetchBonusRewardsByProductIds(List.of(1L, 2L));
 	}
 
 	@Test

--- a/item-service/src/test/java/com/comatching/item/domain/product/service/ShopServiceImplTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/product/service/ShopServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +28,9 @@ import com.comatching.item.domain.order.enums.OrderStatus;
 import com.comatching.item.domain.order.repository.OrderRepository;
 import com.comatching.item.domain.order.service.OrderOutboxService;
 import com.comatching.item.domain.product.dto.PurchasePendingStatusResponse;
+import com.comatching.item.domain.product.dto.ProductResponse;
 import com.comatching.item.domain.product.entity.Product;
+import com.comatching.item.domain.product.entity.ProductBonusReward;
 import com.comatching.item.domain.product.entity.ProductReward;
 import com.comatching.item.domain.product.repository.ProductRepository;
 import com.comatching.item.global.exception.ItemErrorCode;
@@ -57,14 +60,11 @@ class ShopServiceImplTest {
 	@DisplayName("상품 ID 기반 요청이면 상품 가격/구성품으로 주문을 생성한다")
 	void shouldCreateOrderFromProductSnapshot() {
 		// given
-		Product product = Product.builder()
-			.name("매칭권 5개 (+옵션권 1개)")
-			.price(5000)
-			.isActive(true)
-			.build();
+		Product product = product("매칭권 10개 (+옵션권 5개)", 5000, true);
 		ReflectionTestUtils.setField(product, "id", 3L);
-		product.addReward(ProductReward.builder().itemType(ItemType.MATCHING_TICKET).quantity(5).build());
-		product.addReward(ProductReward.builder().itemType(ItemType.OPTION_TICKET).quantity(1).build());
+		product.addReward(ProductReward.builder().itemType(ItemType.MATCHING_TICKET).quantity(10).build());
+		product.addReward(ProductReward.builder().itemType(ItemType.OPTION_TICKET).quantity(10).build());
+		product.addBonusReward(ProductBonusReward.builder().itemType(ItemType.OPTION_TICKET).quantity(5).build());
 
 		given(productRepository.findById(3L)).willReturn(Optional.of(product));
 		given(orderRepository.existsActivePendingOrder(eq(100L), any())).willReturn(false);
@@ -79,7 +79,7 @@ class ShopServiceImplTest {
 		Order savedOrder = orderCaptor.getValue();
 
 		assertThat(savedOrder.getMemberId()).isEqualTo(100L);
-		assertThat(savedOrder.getRequestedItemName()).isEqualTo("매칭권 5개 (+옵션권 1개)");
+		assertThat(savedOrder.getRequestedItemName()).isEqualTo("매칭권 10개 (+옵션권 5개)");
 		assertThat(savedOrder.getRequesterRealName()).isEqualTo("홍길동");
 		assertThat(savedOrder.getRequesterUsername()).isEqualTo("길동이");
 		assertThat(savedOrder.getRequestedPrice()).isEqualTo(5000);
@@ -87,12 +87,30 @@ class ShopServiceImplTest {
 		assertThat(savedOrder.getStatus()).isEqualTo(OrderStatus.PENDING);
 		assertThat(savedOrder.getOrderItems()).hasSize(2);
 		assertThat(savedOrder.getOrderItems()).anyMatch(
-			item -> item.getItemType() == ItemType.MATCHING_TICKET && item.getQuantity() == 5
+			item -> item.getItemType() == ItemType.MATCHING_TICKET && item.getQuantity() == 10
 		);
 		assertThat(savedOrder.getOrderItems()).anyMatch(
-			item -> item.getItemType() == ItemType.OPTION_TICKET && item.getQuantity() == 1
+			item -> item.getItemType() == ItemType.OPTION_TICKET && item.getQuantity() == 10
 		);
 		then(orderOutboxService).should().enqueueOrderCreated(savedOrder);
+	}
+
+	@Test
+	@DisplayName("활성 상품만 노출 순서와 ID 순서대로 조회한다")
+	void shouldGetActiveProductsOrderedByDisplayOrderAndId() {
+		// given
+		Product first = product("첫 번째 상품", 1000, true);
+		Product second = product("두 번째 상품", 2000, true);
+		ReflectionTestUtils.setField(first, "id", 1L);
+		ReflectionTestUtils.setField(second, "id", 2L);
+		given(productRepository.findByIsActiveTrueOrderByDisplayOrderAscIdAsc()).willReturn(List.of(first, second));
+
+		// when
+		List<ProductResponse> responses = shopService.getActiveProducts();
+
+		// then
+		assertThat(responses).extracting(ProductResponse::id).containsExactly(1L, 2L);
+		assertThat(responses).extracting(ProductResponse::isActive).containsExactly(true, true);
 	}
 
 	@Test
@@ -112,11 +130,7 @@ class ShopServiceImplTest {
 	@DisplayName("비활성 상품이면 구매 요청이 불가하다")
 	void shouldThrowWhenProductIsNotActive() {
 		// given
-		Product product = Product.builder()
-			.name("비활성 상품")
-			.price(1000)
-			.isActive(false)
-			.build();
+		Product product = product("비활성 상품", 1000, false);
 		given(productRepository.findById(3L)).willReturn(Optional.of(product));
 
 		// when & then
@@ -130,11 +144,7 @@ class ShopServiceImplTest {
 	@DisplayName("대기중 주문이 있으면 새 요청을 막는다")
 	void shouldBlockWhenPendingRequestExists() {
 		// given
-		Product product = Product.builder()
-			.name("매칭권 패키지")
-			.price(9900)
-			.isActive(true)
-			.build();
+		Product product = product("매칭권 패키지", 9900, true);
 		given(productRepository.findById(3L)).willReturn(Optional.of(product));
 		given(orderRepository.existsActivePendingOrder(eq(100L), any())).willReturn(true);
 
@@ -150,11 +160,7 @@ class ShopServiceImplTest {
 	@DisplayName("회원 실명이 없으면 예외가 발생한다")
 	void shouldThrowWhenRealNameMissing() {
 		// given
-		Product product = Product.builder()
-			.name("매칭권 패키지")
-			.price(9900)
-			.isActive(true)
-			.build();
+		Product product = product("매칭권 패키지", 9900, true);
 		given(productRepository.findById(3L)).willReturn(Optional.of(product));
 		given(orderRepository.existsActivePendingOrder(eq(100L), any())).willReturn(false);
 		given(userOrderClient.getOrdererInfo(100L)).willReturn(new OrdererInfoDto(100L, null, "길동이"));
@@ -170,11 +176,7 @@ class ShopServiceImplTest {
 	@DisplayName("회원 닉네임이 없으면 예외가 발생한다")
 	void shouldThrowWhenUsernameMissing() {
 		// given
-		Product product = Product.builder()
-			.name("매칭권 패키지")
-			.price(9900)
-			.isActive(true)
-			.build();
+		Product product = product("매칭권 패키지", 9900, true);
 		given(productRepository.findById(3L)).willReturn(Optional.of(product));
 		given(orderRepository.existsActivePendingOrder(eq(100L), any())).willReturn(false);
 		given(userOrderClient.getOrdererInfo(100L)).willReturn(new OrdererInfoDto(100L, "홍길동", null));
@@ -210,5 +212,15 @@ class ShopServiceImplTest {
 
 		// then
 		assertThat(response.status()).isEqualTo("NONE");
+	}
+
+	private Product product(String name, int price, boolean isActive) {
+		return Product.builder()
+			.name(name)
+			.description("상품 설명")
+			.price(price)
+			.displayOrder(1)
+			.isActive(isActive)
+			.build();
 	}
 }

--- a/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingHistoryServiceImplTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingHistoryServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.comatching.matching.domain.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.comatching.common.dto.member.ProfileResponse;
+import com.comatching.common.dto.member.ProfileTagDto;
+import com.comatching.common.dto.response.PagingResponse;
+import com.comatching.matching.domain.dto.MatchingHistoryResponse;
+import com.comatching.matching.domain.entity.MatchingHistory;
+import com.comatching.matching.domain.repository.history.MatchingHistoryRepository;
+import com.comatching.matching.infra.client.MemberClient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MatchingHistoryServiceImpl 테스트")
+class MatchingHistoryServiceImplTest {
+
+	@InjectMocks
+	private MatchingHistoryServiceImpl matchingHistoryService;
+
+	@Mock
+	private MatchingHistoryRepository historyRepository;
+
+	@Mock
+	private MemberClient memberClient;
+
+	@Test
+	@DisplayName("매칭 히스토리 응답에 파트너 장점 태그가 포함된다")
+	void shouldReturnPartnerTagsInHistory() {
+		// given
+		Long memberId = 1L;
+		Long partnerId = 2L;
+		Pageable pageable = PageRequest.of(0, 10);
+		MatchingHistory history = MatchingHistory.builder()
+			.memberId(memberId)
+			.partnerId(partnerId)
+			.build();
+		ProfileResponse partnerProfile = ProfileResponse.builder()
+			.memberId(partnerId)
+			.tags(List.of(
+				new ProfileTagDto("계란형 얼굴"),
+				new ProfileTagDto("밝은 분위기")
+			))
+			.build();
+
+		given(historyRepository.searchHistory(memberId, null, null, pageable))
+			.willReturn(new PageImpl<>(List.of(history), pageable, 1));
+		given(memberClient.getProfiles(List.of(partnerId))).willReturn(List.of(partnerProfile));
+
+		// when
+		PagingResponse<MatchingHistoryResponse> response = matchingHistoryService.getMyMatchingHistory(
+			memberId, null, null, pageable, false
+		);
+
+		// then
+		assertThat(response.content()).hasSize(1);
+		assertThat(response.content().get(0).partner().tags()).extracting(ProfileTagDto::tag)
+			.containsExactly("계란형 얼굴", "밝은 분위기");
+	}
+}

--- a/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingServiceImplTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingServiceImplTest.java
@@ -20,6 +20,7 @@ import com.comatching.common.domain.enums.HobbyCategory;
 import com.comatching.common.domain.enums.ItemType;
 import com.comatching.common.dto.item.ItemConsumption;
 import com.comatching.common.dto.member.ProfileResponse;
+import com.comatching.common.dto.member.ProfileTagDto;
 import com.comatching.common.exception.BusinessException;
 import com.comatching.matching.domain.component.MatchingItemPolicy;
 import com.comatching.matching.domain.component.MatchingProcessor;
@@ -67,6 +68,20 @@ class MatchingServiceImplTest {
 			.build();
 	}
 
+	private ProfileResponse createProfileWithTags(Long memberId, Gender gender) {
+		return ProfileResponse.builder()
+			.memberId(memberId)
+			.gender(gender)
+			.mbti("ISTJ")
+			.major("컴퓨터공학과")
+			.birthDate(LocalDate.of(2000, 1, 1))
+			.tags(List.of(
+				new ProfileTagDto("계란형 얼굴"),
+				new ProfileTagDto("밝은 분위기")
+			))
+			.build();
+	}
+
 	private MatchingCandidate createCandidate(Long memberId) {
 		return MatchingCandidate.create(
 			memberId, 1L, Gender.FEMALE, "ENFP", "디자인학과",
@@ -88,7 +103,7 @@ class MatchingServiceImplTest {
 			MatchingRequest request = new MatchingRequest(null, "IS", null, null, false, null);
 
 			ProfileResponse myProfile = createProfile(memberId, Gender.MALE);
-			ProfileResponse partnerProfile = createProfile(partnerId, Gender.FEMALE);
+			ProfileResponse partnerProfile = createProfileWithTags(partnerId, Gender.FEMALE);
 			MatchingCandidate partner = createCandidate(partnerId);
 
 			List<ItemConsumption> consumptions = List.of(new ItemConsumption(ItemType.MATCHING_TICKET, 1));
@@ -114,6 +129,8 @@ class MatchingServiceImplTest {
 			// then
 			assertThat(response).isNotNull();
 			assertThat(response.memberId()).isEqualTo(partnerId);
+			assertThat(response.tags()).extracting(ProfileTagDto::tag)
+				.containsExactly("계란형 얼굴", "밝은 분위기");
 			verify(itemClient).useItem(memberId, ItemType.MATCHING_TICKET, 1);
 			verify(matchingEventProducer).sendMatchingSuccess(any());
 		}

--- a/tools/load_test.py
+++ b/tools/load_test.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Small dependency-free HTTP load tester for Comatching.
+
+This is intentionally modest: it is good for smoke/ramp checks from a dev
+machine, while k6/Gatling are still better for long formal performance tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+MATCHING_BODY = {
+    "ageOption": None,
+    "mbtiOption": None,
+    "hobbyOption": None,
+    "contactFrequency": None,
+    "sameMajorOption": False,
+    "importantOption": None,
+    "minAgeOffset": None,
+    "maxAgeOffset": None,
+}
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    name: str
+    method: str
+    path: str
+    body: Optional[dict] = None
+    auth_required: bool = False
+
+
+@dataclass
+class Sample:
+    name: str
+    status: int
+    ms: float
+    error: str = ""
+
+
+SCENARIOS: Dict[str, List[Endpoint]] = {
+    "public": [
+        Endpoint("participants", "GET", "/api/auth/participants"),
+    ],
+    "read": [
+        Endpoint("participants", "GET", "/api/auth/participants"),
+        Endpoint("items", "GET", "/api/items", auth_required=True),
+        Endpoint("matching_history", "GET", "/api/matching/history", auth_required=True),
+    ],
+    "matching": [
+        Endpoint("matching", "POST", "/api/matching", MATCHING_BODY, auth_required=True),
+    ],
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a small Comatching load test.")
+    parser.add_argument("--base-url", required=True, help="Gateway base URL, e.g. http://1.2.3.4:8080")
+    parser.add_argument("--scenario", choices=sorted(SCENARIOS), default="public")
+    parser.add_argument("--vus", type=int, default=10, help="Number of concurrent virtual users")
+    parser.add_argument("--duration", type=int, default=60, help="Duration in seconds")
+    parser.add_argument("--iterations", type=int, help="Total request count. Overrides duration when set")
+    parser.add_argument("--think-time", type=float, default=1.0, help="Sleep seconds between each VU iteration")
+    parser.add_argument("--timeout", type=float, default=5.0, help="Per-request timeout seconds")
+    parser.add_argument("--token", help="Single access token to send as a cookie")
+    parser.add_argument("--tokens-file", help="File with one access token per line")
+    parser.add_argument("--cookie-name", default="accessToken")
+    parser.add_argument("--header", action="append", default=[], help="Extra header, format: Name: value")
+    parser.add_argument(
+        "--allow-write",
+        action="store_true",
+        help="Required for write scenarios such as matching",
+    )
+    return parser.parse_args()
+
+
+def load_tokens(args: argparse.Namespace) -> List[str]:
+    tokens: List[str] = []
+    if args.token:
+        tokens.append(args.token.strip())
+    if args.tokens_file:
+        with open(args.tokens_file, "r", encoding="utf-8") as token_file:
+            tokens.extend(line.strip() for line in token_file if line.strip() and not line.startswith("#"))
+    return tokens
+
+
+def parse_headers(raw_headers: Iterable[str]) -> Dict[str, str]:
+    headers: Dict[str, str] = {}
+    for raw in raw_headers:
+        if ":" not in raw:
+            raise ValueError(f"Invalid --header value: {raw!r}. Expected 'Name: value'.")
+        name, value = raw.split(":", 1)
+        headers[name.strip()] = value.strip()
+    return headers
+
+
+def build_request(
+    base_url: str,
+    endpoint: Endpoint,
+    headers: Dict[str, str],
+    tokens: List[str],
+    cookie_name: str,
+    token_override: Optional[str] = None,
+) -> urllib.request.Request:
+    url = urllib.parse.urljoin(base_url.rstrip("/") + "/", endpoint.path.lstrip("/"))
+    request_headers = dict(headers)
+    data = None
+
+    if endpoint.auth_required:
+        token = token_override or (random.choice(tokens) if tokens else None)
+        if token:
+            request_headers["Cookie"] = f"{cookie_name}={token}"
+
+    if endpoint.body is not None:
+        data = json.dumps(endpoint.body).encode("utf-8")
+        request_headers.setdefault("Content-Type", "application/json")
+
+    return urllib.request.Request(url, data=data, headers=request_headers, method=endpoint.method)
+
+
+def send_once(
+    base_url: str,
+    endpoint: Endpoint,
+    headers: Dict[str, str],
+    tokens: List[str],
+    cookie_name: str,
+    timeout: float,
+    request_index: int = 0,
+) -> Sample:
+    started = time.perf_counter()
+    status = 0
+    error = ""
+    try:
+        token_override = tokens[request_index % len(tokens)] if tokens else None
+        request = build_request(base_url, endpoint, headers, tokens, cookie_name, token_override)
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = response.status
+            response.read()
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        error = exc.reason or "http_error"
+        try:
+            exc.read()
+        except Exception:
+            pass
+    except Exception as exc:
+        error = type(exc).__name__
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    return Sample(endpoint.name, status, elapsed_ms, error)
+
+
+def worker(
+    worker_id: int,
+    args: argparse.Namespace,
+    endpoints: List[Endpoint],
+    headers: Dict[str, str],
+    tokens: List[str],
+    stop_at: float,
+    samples: List[Sample],
+    lock: threading.Lock,
+    counter: Dict[str, int],
+) -> None:
+    index = worker_id % len(endpoints)
+    while True:
+        with lock:
+            if args.iterations is not None:
+                if counter["sent"] >= args.iterations:
+                    return
+                request_index = counter["sent"]
+                counter["sent"] += 1
+            else:
+                request_index = counter["sent"]
+                counter["sent"] += 1
+
+        if args.iterations is None and time.perf_counter() >= stop_at:
+            return
+
+        endpoint = endpoints[index % len(endpoints)]
+        sample = send_once(
+            args.base_url,
+            endpoint,
+            headers,
+            tokens,
+            args.cookie_name,
+            args.timeout,
+            request_index,
+        )
+        with lock:
+            samples.append(sample)
+        index += 1
+        if args.think_time > 0:
+            time.sleep(args.think_time)
+
+
+def percentile(values: List[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = int(round((len(ordered) - 1) * pct))
+    return ordered[index]
+
+
+def summarize(samples: List[Sample], duration: float) -> None:
+    total = len(samples)
+    ok = [sample for sample in samples if 200 <= sample.status < 400]
+    failed = total - len(ok)
+    latencies = [sample.ms for sample in samples]
+    print()
+    print("=== Load test summary ===")
+    print(f"requests: {total}")
+    print(f"duration: {duration:.1f}s")
+    print(f"throughput: {(total / duration if duration > 0 else 0):.2f} req/s")
+    print(f"failures: {failed} ({(failed / total * 100 if total else 0):.2f}%)")
+    print(f"latency avg: {(statistics.mean(latencies) if latencies else 0):.1f} ms")
+    print(f"latency p50: {percentile(latencies, 0.50):.1f} ms")
+    print(f"latency p95: {percentile(latencies, 0.95):.1f} ms")
+    print(f"latency max: {(max(latencies) if latencies else 0):.1f} ms")
+    print()
+    print("by endpoint:")
+    for name in sorted({sample.name for sample in samples}):
+        group = [sample for sample in samples if sample.name == name]
+        group_latencies = [sample.ms for sample in group]
+        group_failed = len([sample for sample in group if not 200 <= sample.status < 400])
+        print(
+            f"  {name}: count={len(group)} fail={group_failed} "
+            f"p95={percentile(group_latencies, 0.95):.1f}ms"
+        )
+    print()
+    print("status counts:")
+    counts: Dict[Tuple[int, str], int] = {}
+    for sample in samples:
+        key = (sample.status, sample.error)
+        counts[key] = counts.get(key, 0) + 1
+    for (status, error), count in sorted(counts.items(), key=lambda item: (item[0][0], item[0][1])):
+        label = str(status) if status else error
+        if status and error:
+            label = f"{status} {error}"
+        print(f"  {label}: {count}")
+
+
+def main() -> int:
+    args = parse_args()
+    endpoints = SCENARIOS[args.scenario]
+    writes = any(endpoint.method not in {"GET", "HEAD", "OPTIONS"} for endpoint in endpoints)
+    if writes and not args.allow_write:
+        print(f"Scenario {args.scenario!r} sends write requests. Re-run with --allow-write to confirm.")
+        return 2
+
+    tokens = load_tokens(args)
+    if any(endpoint.auth_required for endpoint in endpoints) and not tokens:
+        print(f"Scenario {args.scenario!r} requires --token or --tokens-file.")
+        return 2
+
+    headers = parse_headers(args.header)
+    samples: List[Sample] = []
+    lock = threading.Lock()
+    stop_at = time.perf_counter() + args.duration
+    counter = {"sent": 0}
+    started = time.perf_counter()
+    run_limit = f"iterations={args.iterations}" if args.iterations is not None else f"duration={args.duration}s"
+    print(
+        f"Running scenario={args.scenario} base_url={args.base_url} "
+        f"vus={args.vus} {run_limit}"
+    )
+
+    with ThreadPoolExecutor(max_workers=args.vus) as executor:
+        futures = [
+            executor.submit(worker, i, args, endpoints, headers, tokens, stop_at, samples, lock, counter)
+            for i in range(args.vus)
+        ]
+        for future in futures:
+            future.result()
+
+    elapsed = time.perf_counter() - started
+    summarize(samples, elapsed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/user-service/src/main/java/com/comatching/user/domain/member/service/ProfileServiceImpl.java
+++ b/user-service/src/main/java/com/comatching/user/domain/member/service/ProfileServiceImpl.java
@@ -369,7 +369,7 @@ public class ProfileServiceImpl implements ProfileCreateService, ProfileManageSe
 				.map(h -> new HobbyDto(h.getCategory(), h.getName()))
 				.toList())
 			.tags(profile.getTags().stream()
-				.map(t -> new ProfileTagDto(t.getTag().name()))
+				.map(t -> new ProfileTagDto(t.getTag().getLabel()))
 				.toList())
 			.build();
 

--- a/user-service/src/test/java/com/comatching/user/domain/member/service/ProfileServiceImplTest.java
+++ b/user-service/src/test/java/com/comatching/user/domain/member/service/ProfileServiceImplTest.java
@@ -100,7 +100,8 @@ class ProfileServiceImplTest {
 			// then
 			assertThat(response).isNotNull();
 			assertThat(response.tags()).hasSize(2);
-			assertThat(response.tags().get(0).tag()).isEqualTo("EGG_FACE");
+			assertThat(response.tags()).extracting(ProfileTagDto::tag)
+				.containsExactly("계란형 얼굴", "밝은 분위기");
 		}
 
 		@Test
@@ -140,7 +141,7 @@ class ProfileServiceImplTest {
 			assertThat(response).isNotNull();
 			assertThat(response.tags()).hasSize(2);
 			assertThat(response.tags()).extracting(ProfileTagDto::tag)
-				.containsExactly("BRIGHT", "GOOD_LISTENER");
+				.containsExactly("밝은 분위기", "경청형");
 		}
 
 		@Test
@@ -340,6 +341,8 @@ class ProfileServiceImplTest {
 
 			// then
 			assertThat(response.tags()).hasSize(2);
+			assertThat(response.tags()).extracting(ProfileTagDto::tag)
+				.containsExactly("마른 체형", "근육질");
 		}
 
 		@Test
@@ -467,7 +470,8 @@ class ProfileServiceImplTest {
 
 			// then
 			assertThat(response).isNotNull();
-			assertThat(response.tags()).isNotEmpty();
+			assertThat(response.tags()).extracting(ProfileTagDto::tag)
+				.containsExactly("계란형 얼굴", "밝은 분위기");
 		}
 	}
 


### PR DESCRIPTION
## 개요
미커밋으로 남아 있던 변경을 성격별 커밋으로 분류하고, 상품 카탈로그 관리 기능/프로필 태그 라벨/매칭 태그 테스트/부하 테스트 도구를 main 대상 PR로 정리했습니다.

Closes #37

@codex

## 변경 사항
- 상품 설명, 노출 순서, 보너스 구성품, 관리자 상품 목록/삭제 API 추가
- 사용자 상품 목록을 displayOrder/id 기준으로 정렬하고 응답 스키마 보강
- 프로필 태그 응답을 enum name 대신 사용자 표시 라벨로 반환
- 매칭 성공/히스토리 응답의 파트너 태그 검증 테스트 추가
- 개발용 HTTP 부하 테스트 스크립트 추가

## 테스트
- [x] 테스트를 실행했습니다. ./gradlew :item-service:test :matching-service:test :user-service:test --rerun-tasks 성공
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- 변경 범위: 미커밋 파일 18개를 4개 커밋으로 분류