### PR TITLE
fix(matching): refund item on finalization failure

### DIFF
--- a/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingServiceImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingServiceImpl.java
@@ -46,25 +46,24 @@ public class MatchingServiceImpl implements MatchingService {
 	private final MatchingProcessor matchingProcessor;
 
 	@Override
-	@DistributedLock(key = "MATCHING_REQUEST", identifier = "#memberId")
+	@DistributedLock(key = "MATCHING_REQUEST", identifier = "#memberId", leaseTime = 15L)
 	public MatchingResponse match(Long memberId, MatchingRequest request) {
 		ProfileResponse myProfile = memberClient.getProfile(memberId);
 		validateAgeLimitRequest(request, myProfile);
 
 		List<ItemConsumption> consumedConsumptions = consumeItems(memberId, request);
 
-		MatchingCandidate matchedCandidate;
 		try {
-			matchedCandidate = matchingProcessor.process(memberId, myProfile, request);
+			MatchingCandidate matchedCandidate = matchingProcessor.process(memberId, myProfile, request);
+			ProfileResponse partnerProfile = memberClient.getProfile(matchedCandidate.getMemberId());
+
+			saveHistoryAndPublishEvent(memberId, matchedCandidate, request);
+
+			return MatchingResponse.of(matchedCandidate, partnerProfile);
 		} catch (Exception e) {
 			refundItems(memberId, consumedConsumptions);
 			throw e;
 		}
-
-		saveHistoryAndPublishEvent(memberId, matchedCandidate, request);
-
-		ProfileResponse partnerProfile = memberClient.getProfile(matchedCandidate.getMemberId());
-		return MatchingResponse.of(matchedCandidate, partnerProfile);
 	}
 
 	private List<ItemConsumption> consumeItems(Long memberId, MatchingRequest request) {

--- a/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingServiceImplTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingServiceImplTest.java
@@ -184,6 +184,92 @@ class MatchingServiceImplTest {
 		}
 
 		@Test
+		@DisplayName("상대 프로필 조회 실패시 아이템을 환불하고 히스토리를 저장하지 않는다")
+		void shouldRefundItemsAndSkipHistoryWhenPartnerProfileLookupFails() {
+			// given
+			Long memberId = 1L;
+			Long partnerId = 2L;
+			MatchingRequest request = new MatchingRequest(null, null, null, null, false, null);
+
+			ProfileResponse myProfile = createProfile(memberId, Gender.MALE);
+			MatchingCandidate partner = createCandidate(partnerId);
+			List<ItemConsumption> consumptions = List.of(new ItemConsumption(ItemType.MATCHING_TICKET, 1));
+
+			given(memberClient.getProfile(memberId)).willReturn(myProfile);
+			given(memberClient.getProfile(partnerId))
+				.willThrow(new BusinessException(MatchingErrorCode.NO_MATCHING_CANDIDATE));
+			given(matchingItemPolicy.determine(request)).willReturn(consumptions);
+			given(matchingProcessor.process(memberId, myProfile, request)).willReturn(partner);
+
+			// when & then
+			assertThatThrownBy(() -> matchingService.match(memberId, request))
+				.isInstanceOf(BusinessException.class);
+
+			verify(itemClient).addItem(eq(memberId), any());
+			verify(historyRepository, never()).save(any());
+			verify(matchingEventProducer, never()).sendMatchingSuccess(any());
+		}
+
+		@Test
+		@DisplayName("히스토리 저장 실패시 아이템을 환불한다")
+		void shouldRefundItemsWhenHistorySaveFails() {
+			// given
+			Long memberId = 1L;
+			Long partnerId = 2L;
+			MatchingRequest request = new MatchingRequest(null, null, null, null, false, null);
+
+			ProfileResponse myProfile = createProfile(memberId, Gender.MALE);
+			ProfileResponse partnerProfile = createProfile(partnerId, Gender.FEMALE);
+			MatchingCandidate partner = createCandidate(partnerId);
+			List<ItemConsumption> consumptions = List.of(new ItemConsumption(ItemType.MATCHING_TICKET, 1));
+
+			given(memberClient.getProfile(memberId)).willReturn(myProfile);
+			given(memberClient.getProfile(partnerId)).willReturn(partnerProfile);
+			given(matchingItemPolicy.determine(request)).willReturn(consumptions);
+			given(matchingProcessor.process(memberId, myProfile, request)).willReturn(partner);
+			given(historyRepository.save(any(MatchingHistory.class))).willThrow(new RuntimeException("history save failed"));
+
+			// when & then
+			assertThatThrownBy(() -> matchingService.match(memberId, request))
+				.isInstanceOf(RuntimeException.class);
+
+			verify(itemClient).addItem(eq(memberId), any());
+			verify(matchingEventProducer, never()).sendMatchingSuccess(any());
+		}
+
+		@Test
+		@DisplayName("매칭 성공 이벤트 발행 실패시 아이템을 환불한다")
+		void shouldRefundItemsWhenEventPublishFails() {
+			// given
+			Long memberId = 1L;
+			Long partnerId = 2L;
+			MatchingRequest request = new MatchingRequest(null, null, null, null, false, null);
+
+			ProfileResponse myProfile = createProfile(memberId, Gender.MALE);
+			ProfileResponse partnerProfile = createProfile(partnerId, Gender.FEMALE);
+			MatchingCandidate partner = createCandidate(partnerId);
+			List<ItemConsumption> consumptions = List.of(new ItemConsumption(ItemType.MATCHING_TICKET, 1));
+			MatchingHistory savedHistory = MatchingHistory.builder()
+				.memberId(memberId)
+				.partnerId(partnerId)
+				.build();
+
+			given(memberClient.getProfile(memberId)).willReturn(myProfile);
+			given(memberClient.getProfile(partnerId)).willReturn(partnerProfile);
+			given(matchingItemPolicy.determine(request)).willReturn(consumptions);
+			given(matchingProcessor.process(memberId, myProfile, request)).willReturn(partner);
+			given(historyRepository.save(any(MatchingHistory.class))).willReturn(savedHistory);
+			willThrow(new RuntimeException("event publish failed"))
+				.given(matchingEventProducer).sendMatchingSuccess(any());
+
+			// when & then
+			assertThatThrownBy(() -> matchingService.match(memberId, request))
+				.isInstanceOf(RuntimeException.class);
+
+			verify(itemClient).addItem(eq(memberId), any());
+		}
+
+		@Test
 		@DisplayName("매칭 성공시 히스토리를 저장하고 이벤트를 발행한다")
 		void shouldSaveHistoryAndPublishEventOnSuccess() {
 			// given


### PR DESCRIPTION
## 개요
매칭 요청에서 아이템 차감 이후 후속 처리 단계가 실패해도 아이템이 환불되도록 보상 범위를 확장합니다.

Closes #39

@codex

## 변경 사항
- 아이템 차감 이후 후보 선택, 상대 프로필 조회, 히스토리 저장, 이벤트 발행을 하나의 환불 보호 범위로 묶었습니다.
- 상대 프로필 조회를 히스토리 저장 전에 수행해 실패 시 매칭 내역을 남기지 않고 환불되도록 조정했습니다.
- 매칭 요청 분산락 leaseTime을 15초로 늘렸습니다.
- 상대 프로필 조회 실패, 히스토리 저장 실패, 이벤트 발행 실패 보상 테스트를 추가했습니다.

## 테스트
- [x] 테스트를 실행했습니다.
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

실행한 테스트:
- `./gradlew :matching-service:test --tests com.comatching.matching.domain.service.MatchingServiceImplTest`
- `./gradlew :matching-service:test`

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
상세 원인 분석과 운영 전 검증 기록은 내부 Notion 문서를 참고합니다.
