### PR TITLE
fix(matching): bound candidate scan

### DIFF
--- a/matching-service/src/main/java/com/comatching/matching/domain/component/MatchingProcessor.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/component/MatchingProcessor.java
@@ -38,9 +38,25 @@ public class MatchingProcessor {
 
 	public MatchingCandidate process(Long memberId, ProfileResponse myProfile, MatchingRequest request) {
 		KoreanAge myAge = KoreanAge.fromBirthDate(myProfile.birthDate());
-		List<MatchingCandidate> candidates = findCandidates(memberId, myProfile, request, myAge);
+		List<Long> excludeMemberIds = historyRepository.findPartnerIdsByMemberId(memberId);
+		MatchingCandidateSearchSeed searchSeed = createSearchSeed(myProfile, request, myAge, excludeMemberIds);
+		List<MatchingCandidate> bestCandidates = new ArrayList<>();
+		int maxScore = -1;
+		Long lastMemberId = null;
 
-		List<MatchingCandidate> bestCandidates = filterAndScore(candidates, request, myAge);
+		while (true) {
+			List<MatchingCandidate> candidates = candidateRepository.findPotentialCandidates(searchSeed.toCondition(lastMemberId));
+			if (candidates.isEmpty()) {
+				break;
+			}
+
+			maxScore = filterAndScore(candidates, request, myAge, bestCandidates, maxScore);
+			lastMemberId = candidates.get(candidates.size() - 1).getMemberId();
+
+			if (candidates.size() < MAX_CANDIDATE_FETCH_SIZE) {
+				break;
+			}
+		}
 
 		if (bestCandidates.isEmpty()) {
 			throw new BusinessException(MatchingErrorCode.NO_MATCHING_CANDIDATE);
@@ -49,16 +65,15 @@ public class MatchingProcessor {
 		return selectRandomCandidate(bestCandidates);
 	}
 
-	private List<MatchingCandidate> findCandidates(
-		Long memberId,
+	private MatchingCandidateSearchSeed createSearchSeed(
 		ProfileResponse myProfile,
 		MatchingRequest request,
-		KoreanAge myAge
+		KoreanAge myAge,
+		List<Long> excludeMemberIds
 	) {
-		List<Long> excludeMemberIds = historyRepository.findPartnerIdsByMemberId(memberId);
 		String excludeMajor = request.sameMajorOption() ? myProfile.major() : null;
 		Gender targetGender = (myProfile.gender() == Gender.MALE) ? Gender.FEMALE : Gender.MALE;
-		MatchingCandidateSearchCondition condition = new MatchingCandidateSearchCondition(
+		return new MatchingCandidateSearchSeed(
 			targetGender,
 			excludeMajor,
 			excludeMemberIds,
@@ -69,8 +84,6 @@ public class MatchingProcessor {
 			requiredHobbyCategory(request),
 			MAX_CANDIDATE_FETCH_SIZE
 		);
-
-		return candidateRepository.findPotentialCandidates(condition);
 	}
 
 	private Integer minAge(MatchingRequest request, KoreanAge myAge) {
@@ -125,12 +138,13 @@ public class MatchingProcessor {
 		return request.importantOption() == ImportantOption.HOBBY ? request.hobbyOption() : null;
 	}
 
-	private List<MatchingCandidate> filterAndScore(List<MatchingCandidate> candidates,
-		MatchingRequest request, KoreanAge myAge) {
-
-		List<MatchingCandidate> bestCandidates = new ArrayList<>();
-		int maxScore = -1;
-
+	private int filterAndScore(
+		List<MatchingCandidate> candidates,
+		MatchingRequest request,
+		KoreanAge myAge,
+		List<MatchingCandidate> bestCandidates,
+		int maxScore
+	) {
 		for (MatchingCandidate candidate : candidates) {
 			if (!matchesAgeLimit(candidate, request, myAge)) {
 				continue;
@@ -151,7 +165,7 @@ public class MatchingProcessor {
 			}
 		}
 
-		return bestCandidates;
+		return maxScore;
 	}
 
 	private boolean matchesAgeLimit(MatchingCandidate candidate, MatchingRequest request, KoreanAge myAge) {
@@ -177,5 +191,33 @@ public class MatchingProcessor {
 	private MatchingCandidate selectRandomCandidate(List<MatchingCandidate> candidates) {
 		int randomIndex = (int) (Math.random() * candidates.size());
 		return candidates.get(randomIndex);
+	}
+
+	private record MatchingCandidateSearchSeed(
+		Gender targetGender,
+		String excludeMajor,
+		List<Long> excludeMemberIds,
+		Integer minAge,
+		Integer maxAge,
+		String requiredMbtiTraits,
+		ContactFrequency requiredContactFrequency,
+		HobbyCategory requiredHobbyCategory,
+		int limit
+	) {
+
+		private MatchingCandidateSearchCondition toCondition(Long lastMemberId) {
+			return new MatchingCandidateSearchCondition(
+				targetGender,
+				excludeMajor,
+				excludeMemberIds,
+				minAge,
+				maxAge,
+				requiredMbtiTraits,
+				requiredContactFrequency,
+				requiredHobbyCategory,
+				lastMemberId,
+				limit
+			);
+		}
 	}
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/component/MatchingProcessor.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/component/MatchingProcessor.java
@@ -2,16 +2,22 @@ package com.comatching.matching.domain.component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.springframework.stereotype.Component;
 
+import com.comatching.common.domain.enums.ContactFrequency;
 import com.comatching.common.domain.enums.Gender;
+import com.comatching.common.domain.enums.HobbyCategory;
 import com.comatching.common.domain.vo.KoreanAge;
 import com.comatching.common.dto.member.ProfileResponse;
 import com.comatching.common.exception.BusinessException;
 import com.comatching.matching.domain.dto.MatchingRequest;
 import com.comatching.matching.domain.entity.MatchingCandidate;
+import com.comatching.matching.domain.enums.AgeOption;
+import com.comatching.matching.domain.enums.ImportantOption;
 import com.comatching.matching.domain.repository.candidate.MatchingCandidateRepository;
+import com.comatching.matching.domain.repository.candidate.MatchingCandidateSearchCondition;
 import com.comatching.matching.domain.repository.history.MatchingHistoryRepository;
 import com.comatching.matching.global.exception.MatchingErrorCode;
 
@@ -23,6 +29,7 @@ public class MatchingProcessor {
 
 	private static final int MIN_ALLOWED_AGE = 20;
 	private static final int MAX_ALLOWED_AGE = 27;
+	private static final int MAX_CANDIDATE_FETCH_SIZE = 500;
 
 	private final MatchingCandidateRepository candidateRepository;
 	private final MatchingHistoryRepository historyRepository;
@@ -30,8 +37,8 @@ public class MatchingProcessor {
 	private final ImportantConditionCheckerFactory conditionCheckerFactory;
 
 	public MatchingCandidate process(Long memberId, ProfileResponse myProfile, MatchingRequest request) {
-		List<MatchingCandidate> candidates = findCandidates(memberId, myProfile, request);
 		KoreanAge myAge = KoreanAge.fromBirthDate(myProfile.birthDate());
+		List<MatchingCandidate> candidates = findCandidates(memberId, myProfile, request, myAge);
 
 		List<MatchingCandidate> bestCandidates = filterAndScore(candidates, request, myAge);
 
@@ -42,12 +49,80 @@ public class MatchingProcessor {
 		return selectRandomCandidate(bestCandidates);
 	}
 
-	private List<MatchingCandidate> findCandidates(Long memberId, ProfileResponse myProfile, MatchingRequest request) {
+	private List<MatchingCandidate> findCandidates(
+		Long memberId,
+		ProfileResponse myProfile,
+		MatchingRequest request,
+		KoreanAge myAge
+	) {
 		List<Long> excludeMemberIds = historyRepository.findPartnerIdsByMemberId(memberId);
 		String excludeMajor = request.sameMajorOption() ? myProfile.major() : null;
 		Gender targetGender = (myProfile.gender() == Gender.MALE) ? Gender.FEMALE : Gender.MALE;
+		MatchingCandidateSearchCondition condition = new MatchingCandidateSearchCondition(
+			targetGender,
+			excludeMajor,
+			excludeMemberIds,
+			minAge(request, myAge),
+			maxAge(request, myAge),
+			requiredMbtiTraits(request),
+			requiredContactFrequency(request),
+			requiredHobbyCategory(request),
+			MAX_CANDIDATE_FETCH_SIZE
+		);
 
-		return candidateRepository.findPotentialCandidates(targetGender, excludeMajor, excludeMemberIds);
+		return candidateRepository.findPotentialCandidates(condition);
+	}
+
+	private Integer minAge(MatchingRequest request, KoreanAge myAge) {
+		Integer minAge = null;
+		if (request.hasCompleteAgeLimit() && myAge != null) {
+			minAge = Math.max(MIN_ALLOWED_AGE, myAge.getValue() + request.minAgeOffset());
+		}
+		if (request.importantOption() == ImportantOption.AGE && request.ageOption() == AgeOption.EQUAL && myAge != null) {
+			minAge = max(minAge, myAge.getValue());
+		}
+		if (request.importantOption() == ImportantOption.AGE && request.ageOption() == AgeOption.OLDER && myAge != null) {
+			minAge = max(minAge, myAge.getValue() + 1);
+		}
+		return minAge;
+	}
+
+	private Integer maxAge(MatchingRequest request, KoreanAge myAge) {
+		Integer maxAge = null;
+		if (request.hasCompleteAgeLimit() && myAge != null) {
+			maxAge = Math.min(MAX_ALLOWED_AGE, myAge.getValue() + request.maxAgeOffset());
+		}
+		if (request.importantOption() == ImportantOption.AGE && request.ageOption() == AgeOption.EQUAL && myAge != null) {
+			maxAge = min(maxAge, myAge.getValue());
+		}
+		if (request.importantOption() == ImportantOption.AGE && request.ageOption() == AgeOption.YOUNGER && myAge != null) {
+			maxAge = min(maxAge, myAge.getValue() - 1);
+		}
+		return maxAge;
+	}
+
+	private Integer max(Integer current, int candidate) {
+		return current == null ? candidate : Math.max(current, candidate);
+	}
+
+	private Integer min(Integer current, int candidate) {
+		return current == null ? candidate : Math.min(current, candidate);
+	}
+
+	private String requiredMbtiTraits(MatchingRequest request) {
+		if (request.importantOption() != ImportantOption.MBTI || request.mbtiOption() == null
+			|| request.mbtiOption().isBlank()) {
+			return null;
+		}
+		return request.mbtiOption().toUpperCase(Locale.ROOT);
+	}
+
+	private ContactFrequency requiredContactFrequency(MatchingRequest request) {
+		return request.importantOption() == ImportantOption.CONTACT ? request.contactFrequency() : null;
+	}
+
+	private HobbyCategory requiredHobbyCategory(MatchingRequest request) {
+		return request.importantOption() == ImportantOption.HOBBY ? request.hobbyOption() : null;
 	}
 
 	private List<MatchingCandidate> filterAndScore(List<MatchingCandidate> candidates,

--- a/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingCandidate.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/entity/MatchingCandidate.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
+
 import com.comatching.common.domain.enums.ContactFrequency;
 import com.comatching.common.domain.enums.Gender;
 import com.comatching.common.domain.enums.HobbyCategory;
@@ -65,6 +67,7 @@ public class MatchingCandidate {
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "candidate_hobby_categories", joinColumns = @JoinColumn(name = "member_id"))
 	@Enumerated(EnumType.STRING)
+	@BatchSize(size = 100)
 	private List<HobbyCategory> hobbyCategories = new ArrayList<>();
 
 	public void syncProfile(

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryCustom.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryCustom.java
@@ -2,14 +2,9 @@ package com.comatching.matching.domain.repository.candidate;
 
 import java.util.List;
 
-import com.comatching.common.domain.enums.Gender;
 import com.comatching.matching.domain.entity.MatchingCandidate;
 
 public interface MatchingCandidateRepositoryCustom {
 
-	List<MatchingCandidate> findPotentialCandidates(
-		Gender targetGender,
-		String excludeMajor,
-		List<Long> excludeMemberIds
-	);
+	List<MatchingCandidate> findPotentialCandidates(MatchingCandidateSearchCondition condition);
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
@@ -31,8 +31,10 @@ public class MatchingCandidateRepositoryImpl implements MatchingCandidateReposit
 				ageLoe(condition.maxAge()),
 				containsAllMbtiTraits(condition.requiredMbtiTraits()),
 				eqContactFrequency(condition.requiredContactFrequency()),
-				hasHobbyCategory(condition.requiredHobbyCategory())
+				hasHobbyCategory(condition.requiredHobbyCategory()),
+				memberIdGt(condition.lastMemberIdExclusive())
 			)
+			.orderBy(matchingCandidate.memberId.asc())
 			.limit(condition.limit())
 			.fetch();
 	}
@@ -74,5 +76,9 @@ public class MatchingCandidateRepositoryImpl implements MatchingCandidateReposit
 
 	private BooleanExpression hasHobbyCategory(HobbyCategory hobbyCategory) {
 		return hobbyCategory != null ? matchingCandidate.hobbyCategories.any().eq(hobbyCategory) : null;
+	}
+
+	private BooleanExpression memberIdGt(Long memberId) {
+		return memberId != null ? matchingCandidate.memberId.gt(memberId) : null;
 	}
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
@@ -4,10 +4,10 @@ import static com.comatching.matching.domain.entity.QMatchingCandidate.*;
 
 import java.util.List;
 
-import com.comatching.common.domain.enums.Gender;
+import com.comatching.common.domain.enums.ContactFrequency;
+import com.comatching.common.domain.enums.HobbyCategory;
 import com.comatching.matching.domain.entity.MatchingCandidate;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -18,20 +18,22 @@ public class MatchingCandidateRepositoryImpl implements MatchingCandidateReposit
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<MatchingCandidate> findPotentialCandidates(
-		Gender targetGender,
-		String excludeMajor,
-		List<Long> excludeMemberIds
-	) {
+	public List<MatchingCandidate> findPotentialCandidates(MatchingCandidateSearchCondition condition) {
 
 		return queryFactory
 			.selectFrom(matchingCandidate)
 			.where(
-				matchingCandidate.gender.eq(targetGender),
+				matchingCandidate.gender.eq(condition.targetGender()),
 				matchingCandidate.isMatchable.isTrue(),
-				neMajor(excludeMajor),
-				notInMemberIds(excludeMemberIds)
+				neMajor(condition.excludeMajor()),
+				notInMemberIds(condition.excludeMemberIds()),
+				ageGoe(condition.minAge()),
+				ageLoe(condition.maxAge()),
+				containsAllMbtiTraits(condition.requiredMbtiTraits()),
+				eqContactFrequency(condition.requiredContactFrequency()),
+				hasHobbyCategory(condition.requiredHobbyCategory())
 			)
+			.limit(condition.limit())
 			.fetch();
 	}
 
@@ -43,5 +45,34 @@ public class MatchingCandidateRepositoryImpl implements MatchingCandidateReposit
 		return (excludeMemberIds != null && !excludeMemberIds.isEmpty())
 			? matchingCandidate.memberId.notIn(excludeMemberIds)
 			: null;
+	}
+
+	private BooleanExpression ageGoe(Integer minAge) {
+		return minAge != null ? matchingCandidate.age.value.goe(minAge) : null;
+	}
+
+	private BooleanExpression ageLoe(Integer maxAge) {
+		return maxAge != null ? matchingCandidate.age.value.loe(maxAge) : null;
+	}
+
+	private BooleanExpression containsAllMbtiTraits(String traits) {
+		if (traits == null || traits.isBlank()) {
+			return null;
+		}
+
+		BooleanExpression expression = null;
+		for (char trait : traits.toCharArray()) {
+			BooleanExpression traitExpression = matchingCandidate.mbti.value.contains(String.valueOf(trait));
+			expression = expression == null ? traitExpression : expression.and(traitExpression);
+		}
+		return expression;
+	}
+
+	private BooleanExpression eqContactFrequency(ContactFrequency frequency) {
+		return frequency != null ? matchingCandidate.contactFrequency.eq(frequency) : null;
+	}
+
+	private BooleanExpression hasHobbyCategory(HobbyCategory hobbyCategory) {
+		return hobbyCategory != null ? matchingCandidate.hobbyCategories.any().eq(hobbyCategory) : null;
 	}
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateSearchCondition.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateSearchCondition.java
@@ -15,6 +15,7 @@ public record MatchingCandidateSearchCondition(
 	String requiredMbtiTraits,
 	ContactFrequency requiredContactFrequency,
 	HobbyCategory requiredHobbyCategory,
+	Long lastMemberIdExclusive,
 	int limit
 ) {
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateSearchCondition.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateSearchCondition.java
@@ -1,0 +1,20 @@
+package com.comatching.matching.domain.repository.candidate;
+
+import java.util.List;
+
+import com.comatching.common.domain.enums.ContactFrequency;
+import com.comatching.common.domain.enums.Gender;
+import com.comatching.common.domain.enums.HobbyCategory;
+
+public record MatchingCandidateSearchCondition(
+	Gender targetGender,
+	String excludeMajor,
+	List<Long> excludeMemberIds,
+	Integer minAge,
+	Integer maxAge,
+	String requiredMbtiTraits,
+	ContactFrequency requiredContactFrequency,
+	HobbyCategory requiredHobbyCategory,
+	int limit
+) {
+}

--- a/matching-service/src/test/java/com/comatching/matching/domain/component/MatchingProcessorTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/component/MatchingProcessorTest.java
@@ -6,11 +6,13 @@ import static org.mockito.BDDMockito.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -279,6 +281,39 @@ class MatchingProcessorTest {
 					&& condition.requiredContactFrequency() == null
 					&& condition.limit() == 500
 			));
+		}
+
+		@Test
+		@DisplayName("첫 후보 페이지에 매칭 대상이 없어도 다음 페이지를 조회한다")
+		void shouldContinueSearchWhenFirstPageHasNoFinalCandidate() {
+			// given
+			Long memberId = 1L;
+			ProfileResponse myProfile = createProfile(memberId, Gender.MALE, 23);
+			MatchingRequest request = new MatchingRequest(
+				null, null, null, null, false, null,
+				-1, 1
+			);
+			List<MatchingCandidate> firstPage = LongStream.rangeClosed(2L, 501L)
+				.mapToObj(id -> createCandidate(id, "ISTJ", 19))
+				.toList();
+			MatchingCandidate secondPageCandidate = createCandidate(600L, "ENFP", 23);
+
+			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
+				.willReturn(firstPage, List.of(secondPageCandidate));
+			given(conditionCheckerFactory.check(isNull(), eq(secondPageCandidate), eq(request), any())).willReturn(true);
+			given(scoreCalculator.calculate(eq(secondPageCandidate), eq(request), any(KoreanAge.class))).willReturn(30);
+
+			// when
+			MatchingCandidate result = matchingProcessor.process(memberId, myProfile, request);
+
+			// then
+			assertThat(result.getMemberId()).isEqualTo(600L);
+			ArgumentCaptor<MatchingCandidateSearchCondition> conditionCaptor =
+				ArgumentCaptor.forClass(MatchingCandidateSearchCondition.class);
+			verify(candidateRepository, times(2)).findPotentialCandidates(conditionCaptor.capture());
+			assertThat(conditionCaptor.getAllValues().get(0).lastMemberIdExclusive()).isNull();
+			assertThat(conditionCaptor.getAllValues().get(1).lastMemberIdExclusive()).isEqualTo(501L);
 		}
 
 		@Test

--- a/matching-service/src/test/java/com/comatching/matching/domain/component/MatchingProcessorTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/component/MatchingProcessorTest.java
@@ -26,6 +26,7 @@ import com.comatching.matching.domain.entity.MatchingCandidate;
 import com.comatching.matching.domain.enums.AgeOption;
 import com.comatching.matching.domain.enums.ImportantOption;
 import com.comatching.matching.domain.repository.candidate.MatchingCandidateRepository;
+import com.comatching.matching.domain.repository.candidate.MatchingCandidateSearchCondition;
 import com.comatching.matching.domain.repository.history.MatchingHistoryRepository;
 import com.comatching.matching.global.exception.MatchingErrorCode;
 
@@ -82,7 +83,7 @@ class MatchingProcessorTest {
 			List<MatchingCandidate> candidates = List.of(candidate1, candidate2);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), isNull(), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(candidates);
 			given(conditionCheckerFactory.check(isNull(), any(), any(), any())).willReturn(true);
 			given(scoreCalculator.calculate(eq(candidate1), eq(request), any(KoreanAge.class))).willReturn(40);
@@ -108,7 +109,7 @@ class MatchingProcessorTest {
 			List<MatchingCandidate> candidates = List.of(candidate1, candidate2);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), isNull(), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(candidates);
 			given(conditionCheckerFactory.check(eq(ImportantOption.AGE), eq(candidate1), eq(request), any()))
 				.willReturn(false);
@@ -136,7 +137,7 @@ class MatchingProcessorTest {
 			List<MatchingCandidate> candidates = List.of(candidate1, candidate2);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), isNull(), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(candidates);
 			given(conditionCheckerFactory.check(isNull(), any(), any(), any())).willReturn(true);
 			given(scoreCalculator.calculate(any(), eq(request), any(KoreanAge.class))).willReturn(20);
@@ -157,7 +158,7 @@ class MatchingProcessorTest {
 			MatchingRequest request = new MatchingRequest(null, null, null, null, false, null);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), isNull(), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(new ArrayList<>());
 
 			// when & then
@@ -177,7 +178,7 @@ class MatchingProcessorTest {
 			List<MatchingCandidate> candidates = List.of(candidate1);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), isNull(), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(candidates);
 			given(conditionCheckerFactory.check(eq(ImportantOption.AGE), any(), eq(request), any()))
 				.willReturn(false);
@@ -199,7 +200,7 @@ class MatchingProcessorTest {
 			List<MatchingCandidate> candidates = List.of(candidate);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), eq("컴퓨터공학과"), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(candidates);
 			given(conditionCheckerFactory.check(isNull(), any(), any(), any())).willReturn(true);
 			given(scoreCalculator.calculate(any(), eq(request), any(KoreanAge.class))).willReturn(20);
@@ -208,7 +209,10 @@ class MatchingProcessorTest {
 			MatchingCandidate result = matchingProcessor.process(memberId, myProfile, request);
 
 			// then
-			verify(candidateRepository).findPotentialCandidates(eq(Gender.FEMALE), eq("컴퓨터공학과"), anyList());
+			verify(candidateRepository).findPotentialCandidates(argThat(condition ->
+				condition.targetGender() == Gender.FEMALE
+					&& "컴퓨터공학과".equals(condition.excludeMajor())
+			));
 			assertThat(result).isNotNull();
 		}
 
@@ -228,7 +232,7 @@ class MatchingProcessorTest {
 			List<MatchingCandidate> candidates = List.of(age19, age27);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), isNull(), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(candidates);
 			given(conditionCheckerFactory.check(isNull(), any(), any(), any())).willReturn(true);
 			given(scoreCalculator.calculate(eq(age27), eq(request), any(KoreanAge.class))).willReturn(30);
@@ -238,7 +242,43 @@ class MatchingProcessorTest {
 
 			// then
 			assertThat(result.getMemberId()).isEqualTo(3L);
+			verify(candidateRepository).findPotentialCandidates(argThat(condition ->
+				condition.minAge() == 20
+					&& condition.maxAge() == 27
+					&& condition.limit() == 500
+			));
 			verify(scoreCalculator, never()).calculate(eq(age19), eq(request), any(KoreanAge.class));
+		}
+
+		@Test
+		@DisplayName("중요 취미 조건이 있으면 후보 조회 조건으로 전달한다")
+		void shouldPushImportantHobbyToCandidateSearchCondition() {
+			// given
+			Long memberId = 1L;
+			ProfileResponse myProfile = createProfile(memberId, Gender.MALE, 25);
+			MatchingRequest request = new MatchingRequest(
+				null, null, HobbyCategory.SPORTS, null, false, ImportantOption.HOBBY
+			);
+
+			MatchingCandidate candidate = createCandidate(2L, "ISTJ", 25);
+
+			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
+				.willReturn(List.of(candidate));
+			given(conditionCheckerFactory.check(eq(ImportantOption.HOBBY), eq(candidate), eq(request), any()))
+				.willReturn(true);
+			given(scoreCalculator.calculate(eq(candidate), eq(request), any(KoreanAge.class))).willReturn(30);
+
+			// when
+			MatchingCandidate result = matchingProcessor.process(memberId, myProfile, request);
+
+			// then
+			assertThat(result.getMemberId()).isEqualTo(2L);
+			verify(candidateRepository).findPotentialCandidates(argThat(condition ->
+				condition.requiredHobbyCategory() == HobbyCategory.SPORTS
+					&& condition.requiredContactFrequency() == null
+					&& condition.limit() == 500
+			));
 		}
 
 		@Test
@@ -257,7 +297,7 @@ class MatchingProcessorTest {
 			List<MatchingCandidate> candidates = List.of(age19, age27);
 
 			given(historyRepository.findPartnerIdsByMemberId(memberId)).willReturn(new ArrayList<>());
-			given(candidateRepository.findPotentialCandidates(eq(Gender.FEMALE), isNull(), anyList()))
+			given(candidateRepository.findPotentialCandidates(any(MatchingCandidateSearchCondition.class)))
 				.willReturn(candidates);
 
 			// when & then


### PR DESCRIPTION
## 개요
매칭 후보 조회가 전체 active candidate 풀을 무제한으로 가져오지 않도록 조회 조건과 상한을 추가했습니다.

Closes #41

@codex

## 변경 사항
- 매칭 후보 검색 조건을 `MatchingCandidateSearchCondition`으로 묶고 repository 쿼리에 전달합니다.
- 나이 제한, 중요 나이/MBTI/취미/연락 빈도 조건을 DB 조회 조건으로 일부 이전했습니다.
- 후보 조회 상한을 500개로 제한하고, 취미 컬렉션은 batch loading되도록 설정했습니다.
- 후보 조회 조건 전달을 검증하는 테스트를 보강했습니다.

## 테스트
- [x] 테스트를 실행했습니다. `./gradlew :matching-service:test` 성공
- [x] 테스트를 실행했습니다. `./gradlew test` 성공
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- 성능 리뷰 Finding 1 대응