### PR TITLE
fix(chat): batch unread counts

### DIFF
--- a/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatMessageRepository.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatMessageRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import com.comatching.chat.domain.entity.ChatMessage;
 
 @Repository
-public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String>, ChatMessageRepositoryCustom {
 
 	List<ChatMessage> findByRoomIdOrderByCreatedAtDesc(String roomId, Pageable pageable);
 

--- a/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatMessageRepositoryCustom.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatMessageRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.comatching.chat.domain.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ChatMessageRepositoryCustom {
+
+	Map<String, Long> countUnreadMessagesByRoom(List<UnreadCountCondition> conditions, Long myMemberId);
+}

--- a/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatMessageRepositoryImpl.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatMessageRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.comatching.chat.domain.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
+
+import com.comatching.chat.domain.entity.ChatMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+	private final MongoTemplate mongoTemplate;
+
+	@Override
+	public Map<String, Long> countUnreadMessagesByRoom(List<UnreadCountCondition> conditions, Long myMemberId) {
+		if (conditions.isEmpty()) {
+			return Map.of();
+		}
+
+		Criteria[] unreadRoomCriteria = conditions.stream()
+			.map(this::toUnreadRoomCriteria)
+			.toArray(Criteria[]::new);
+
+		Criteria matchCriteria = new Criteria().andOperator(
+			Criteria.where("senderId").ne(myMemberId),
+			new Criteria().orOperator(unreadRoomCriteria)
+		);
+
+		Aggregation aggregation = Aggregation.newAggregation(
+			Aggregation.match(matchCriteria),
+			Aggregation.group("roomId").count().as("count")
+		);
+
+		return mongoTemplate.aggregate(aggregation, ChatMessage.class, Document.class)
+			.getMappedResults()
+			.stream()
+			.collect(Collectors.toMap(
+				result -> result.getString("_id"),
+				result -> result.get("count", Number.class).longValue()
+			));
+	}
+
+	private Criteria toUnreadRoomCriteria(UnreadCountCondition condition) {
+		Criteria criteria = Criteria.where("roomId").is(condition.roomId());
+		if (condition.lastReadAt() != null) {
+			criteria = criteria.and("createdAt").gt(condition.lastReadAt());
+		}
+		return criteria;
+	}
+}

--- a/chat-service/src/main/java/com/comatching/chat/domain/repository/UnreadCountCondition.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/repository/UnreadCountCondition.java
@@ -1,0 +1,9 @@
+package com.comatching.chat.domain.repository;
+
+import java.time.LocalDateTime;
+
+public record UnreadCountCondition(
+	String roomId,
+	LocalDateTime lastReadAt
+) {
+}

--- a/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImpl.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.comatching.chat.domain.service.chatroom;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.data.domain.Sort;
@@ -12,6 +13,7 @@ import com.comatching.chat.domain.dto.ChatRoomResponse;
 import com.comatching.chat.domain.entity.ChatRoom;
 import com.comatching.chat.domain.repository.ChatMessageRepository;
 import com.comatching.chat.domain.repository.ChatRoomRepository;
+import com.comatching.chat.domain.repository.UnreadCountCondition;
 import com.comatching.chat.domain.service.block.BlockService;
 import com.comatching.common.dto.event.matching.MatchingSuccessEvent;
 
@@ -52,21 +54,17 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		Sort sort = Sort.by(Sort.Direction.DESC, "updatedAt");
 		Set<Long> blockedUserIds = blockService.getBlockedUserIds(memberId);
 
-		return chatRoomRepository.findMyChatRooms(memberId, sort).stream()
+		List<ChatRoom> visibleRooms = chatRoomRepository.findMyChatRooms(memberId, sort).stream()
 			.filter(room -> {
 				Long otherUserId = getOtherUserId(room, memberId);
 				return !blockedUserIds.contains(otherUserId);
 			})
-			.map(room -> {
-				LocalDateTime myLastRead = (memberId.equals(room.getInitiatorUserId()))
-					? room.getInitiatorLastReadAt()
-					: room.getTargetLastReadAt();
+			.toList();
 
-				// 안 읽은 개수 쿼리
-				long count = chatMessageRepository.countUnreadMessages(room.getId(), myLastRead, memberId);
+		Map<String, Long> unreadCountsByRoom = getUnreadCountsByRoom(visibleRooms, memberId);
 
-				return (ChatRoomResponse.from(room, count));
-			})
+		return visibleRooms.stream()
+			.map(room -> ChatRoomResponse.from(room, unreadCountsByRoom.getOrDefault(room.getId(), 0L)))
 			.toList();
 	}
 
@@ -84,20 +82,33 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		List<ChatRoom> myRooms = chatRoomRepository.findMyChatRooms(memberId, sort);
 		Set<Long> blockedUserIds = blockService.getBlockedUserIds(memberId);
 
-		long totalUnread = 0;
-		for (ChatRoom room : myRooms) {
-			Long otherUserId = getOtherUserId(room, memberId);
-			if (blockedUserIds.contains(otherUserId)) {
-				continue;
-			}
+		List<ChatRoom> visibleRooms = myRooms.stream()
+			.filter(room -> {
+				Long otherUserId = getOtherUserId(room, memberId);
+				return !blockedUserIds.contains(otherUserId);
+			})
+			.toList();
 
-			LocalDateTime myReadTime = (memberId.equals(room.getInitiatorUserId()))
-				? room.getInitiatorLastReadAt()
-				: room.getTargetLastReadAt();
+		return getUnreadCountsByRoom(visibleRooms, memberId).values().stream()
+			.mapToLong(Long::longValue)
+			.sum();
+	}
 
-			totalUnread += chatMessageRepository.countUnreadMessages(room.getId(), myReadTime, memberId);
+	private Map<String, Long> getUnreadCountsByRoom(List<ChatRoom> rooms, Long memberId) {
+		if (rooms.isEmpty()) {
+			return Map.of();
 		}
 
-		return totalUnread;
+		List<UnreadCountCondition> unreadCountConditions = rooms.stream()
+			.map(room -> new UnreadCountCondition(room.getId(), getMyLastReadAt(room, memberId)))
+			.toList();
+
+		return chatMessageRepository.countUnreadMessagesByRoom(unreadCountConditions, memberId);
+	}
+
+	private LocalDateTime getMyLastReadAt(ChatRoom room, Long memberId) {
+		return memberId.equals(room.getInitiatorUserId())
+			? room.getInitiatorLastReadAt()
+			: room.getTargetLastReadAt();
 	}
 }

--- a/chat-service/src/test/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImplTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImplTest.java
@@ -1,0 +1,126 @@
+package com.comatching.chat.domain.service.chatroom;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.comatching.chat.domain.dto.ChatRoomResponse;
+import com.comatching.chat.domain.entity.ChatRoom;
+import com.comatching.chat.domain.repository.ChatMessageRepository;
+import com.comatching.chat.domain.repository.ChatRoomRepository;
+import com.comatching.chat.domain.repository.UnreadCountCondition;
+import com.comatching.chat.domain.service.block.BlockService;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceImplTest {
+
+	private static final Long MEMBER_ID = 1L;
+	private static final Long OTHER_MEMBER_ID = 2L;
+	private static final Long SECOND_OTHER_MEMBER_ID = 3L;
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+
+	@Mock
+	private BlockService blockService;
+
+	@InjectMocks
+	private ChatRoomServiceImpl chatRoomService;
+
+	@Test
+	@DisplayName("채팅방 목록의 안 읽은 메시지 수를 한 번에 조회한다")
+	void getMyChatRooms_batchesUnreadCounts() {
+		// given
+		LocalDateTime firstReadAt = LocalDateTime.of(2026, 1, 1, 12, 0);
+		LocalDateTime secondReadAt = LocalDateTime.of(2026, 1, 1, 13, 0);
+		ChatRoom firstRoom = chatRoom("room-1", 100L, MEMBER_ID, OTHER_MEMBER_ID, firstReadAt);
+		ChatRoom secondRoom = chatRoom("room-2", 101L, MEMBER_ID, SECOND_OTHER_MEMBER_ID, secondReadAt);
+
+		given(chatRoomRepository.findMyChatRooms(eq(MEMBER_ID), any(Sort.class)))
+			.willReturn(List.of(firstRoom, secondRoom));
+		given(blockService.getBlockedUserIds(MEMBER_ID)).willReturn(Set.of());
+		given(chatMessageRepository.countUnreadMessagesByRoom(anyList(), eq(MEMBER_ID)))
+			.willReturn(Map.of("room-1", 2L, "room-2", 3L));
+
+		// when
+		List<ChatRoomResponse> result = chatRoomService.getMyChatRooms(MEMBER_ID);
+
+		// then
+		assertThat(result).extracting(ChatRoomResponse::unreadCount)
+			.containsExactly(2L, 3L);
+		then(chatMessageRepository).should().countUnreadMessagesByRoom(
+			argThat(conditions -> containsCondition(conditions, "room-1", firstReadAt)
+				&& containsCondition(conditions, "room-2", secondReadAt)),
+			eq(MEMBER_ID)
+		);
+		then(chatMessageRepository).should(never()).countUnreadMessages(anyString(), any(), anyLong());
+	}
+
+	@Test
+	@DisplayName("전체 안 읽은 메시지 수 조회에서 차단된 방을 제외하고 배치 합산한다")
+	void getTotalUnreadCount_batchesVisibleRooms() {
+		// given
+		LocalDateTime firstReadAt = LocalDateTime.of(2026, 1, 1, 12, 0);
+		LocalDateTime blockedReadAt = LocalDateTime.of(2026, 1, 1, 13, 0);
+		ChatRoom visibleRoom = chatRoom("room-1", 100L, MEMBER_ID, OTHER_MEMBER_ID, firstReadAt);
+		ChatRoom blockedRoom = chatRoom("room-2", 101L, MEMBER_ID, SECOND_OTHER_MEMBER_ID, blockedReadAt);
+
+		given(chatRoomRepository.findMyChatRooms(eq(MEMBER_ID), any(Sort.class)))
+			.willReturn(List.of(visibleRoom, blockedRoom));
+		given(blockService.getBlockedUserIds(MEMBER_ID)).willReturn(Set.of(SECOND_OTHER_MEMBER_ID));
+		given(chatMessageRepository.countUnreadMessagesByRoom(anyList(), eq(MEMBER_ID)))
+			.willReturn(Map.of("room-1", 7L));
+
+		// when
+		long result = chatRoomService.getTotalUnreadCount(MEMBER_ID);
+
+		// then
+		assertThat(result).isEqualTo(7L);
+		then(chatMessageRepository).should().countUnreadMessagesByRoom(
+			argThat(conditions -> conditions.size() == 1
+				&& containsCondition(conditions, "room-1", firstReadAt)
+				&& !containsRoom(conditions, "room-2")),
+			eq(MEMBER_ID)
+		);
+		then(chatMessageRepository).should(never()).countUnreadMessages(anyString(), any(), anyLong());
+	}
+
+	private ChatRoom chatRoom(String id, Long matchingId, Long initiatorId, Long targetId, LocalDateTime readAt) {
+		ChatRoom room = ChatRoom.builder()
+			.matchingId(matchingId)
+			.initiatorUserId(initiatorId)
+			.targetUserId(targetId)
+			.build();
+
+		ReflectionTestUtils.setField(room, "id", id);
+		ReflectionTestUtils.setField(room, "initiatorLastReadAt", readAt);
+		return room;
+	}
+
+	private boolean containsCondition(List<UnreadCountCondition> conditions, String roomId, LocalDateTime lastReadAt) {
+		return conditions.stream()
+			.anyMatch(condition -> roomId.equals(condition.roomId()) && lastReadAt.equals(condition.lastReadAt()));
+	}
+
+	private boolean containsRoom(List<UnreadCountCondition> conditions, String roomId) {
+		return conditions.stream()
+			.anyMatch(condition -> roomId.equals(condition.roomId()));
+	}
+}


### PR DESCRIPTION
## 개요
채팅방 목록과 전체 안 읽은 메시지 수 조회에서 방마다 Mongo count 쿼리를 반복하던 N+1 패턴을 제거하고, 방별 마지막 읽은 시각 조건을 한 번의 aggregation으로 묶어 조회하도록 변경했습니다.

Closes #43

@codex

## 변경 사항
- `ChatMessageRepository`에 custom fragment를 추가해 여러 채팅방의 unread count를 `roomId`별로 한 번에 집계합니다.
- `ChatRoomServiceImpl`에서 차단 사용자를 제외한 visible room 목록을 만든 뒤 unread count 맵을 조회하도록 변경했습니다.
- 채팅방 목록/전체 unread count가 기존 방별 `countUnreadMessages`를 호출하지 않는지 단위 테스트를 추가했습니다.

## 테스트
- [x] 테스트를 실행했습니다. `./gradlew :chat-service:test`
- [x] 테스트를 실행했습니다. `./gradlew test`
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- 성능 리뷰 Finding 2: `ChatRoomServiceImpl`의 채팅방별 unread count 반복 쿼리 병목
