### PR TITLE
fix(user): fetch bulk profile hobbies

### DIFF
--- a/user-service/src/main/java/com/comatching/user/domain/member/repository/ProfileRepository.java
+++ b/user-service/src/main/java/com/comatching/user/domain/member/repository/ProfileRepository.java
@@ -22,4 +22,9 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 		"LEFT JOIN FETCH p.tags " +
 		"WHERE m.id IN :memberIds")
 	List<Profile> findAllByMemberIdIn(@Param("memberIds") List<Long> memberIds);
+
+	@Query("SELECT DISTINCT p FROM Profile p " +
+		"LEFT JOIN FETCH p.hobbies " +
+		"WHERE p.member.id IN :memberIds")
+	List<Profile> findAllWithHobbiesByMemberIdIn(@Param("memberIds") List<Long> memberIds);
 }

--- a/user-service/src/main/java/com/comatching/user/domain/member/service/ProfileServiceImpl.java
+++ b/user-service/src/main/java/com/comatching/user/domain/member/service/ProfileServiceImpl.java
@@ -121,7 +121,14 @@ public class ProfileServiceImpl implements ProfileCreateService, ProfileManageSe
 			return List.of();
 		}
 
-		return profileRepository.findAllByMemberIdIn(memberIds).stream()
+		List<Profile> profiles = profileRepository.findAllByMemberIdIn(memberIds);
+		if (profiles.isEmpty()) {
+			return List.of();
+		}
+
+		profileRepository.findAllWithHobbiesByMemberIdIn(memberIds);
+
+		return profiles.stream()
 			.map(this::toProfileResponse)
 			.toList();
 	}

--- a/user-service/src/test/java/com/comatching/user/domain/member/service/ProfileServiceImplTest.java
+++ b/user-service/src/test/java/com/comatching/user/domain/member/service/ProfileServiceImplTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.comatching.common.domain.enums.ContactFrequency;
 import com.comatching.common.domain.enums.Gender;
@@ -473,15 +474,55 @@ class ProfileServiceImplTest {
 			assertThat(response.tags()).extracting(ProfileTagDto::tag)
 				.containsExactly("계란형 얼굴", "밝은 분위기");
 		}
+
+		@Test
+		@DisplayName("bulk 프로필 조회 전에 취미 목록을 한 번에 초기화한다")
+		void shouldFetchHobbiesWhenGettingProfilesBulk() {
+			// given
+			List<Long> memberIds = List.of(1L, 2L);
+			Profile firstProfile = createProfileWithTags(1L);
+			Profile secondProfile = createProfileWithTags(2L);
+
+			given(profileRepository.findAllByMemberIdIn(memberIds))
+				.willReturn(List.of(firstProfile, secondProfile));
+			given(profileRepository.findAllWithHobbiesByMemberIdIn(memberIds))
+				.willReturn(List.of(firstProfile, secondProfile));
+
+			// when
+			List<ProfileResponse> responses = profileService.getProfilesByIds(memberIds);
+
+			// then
+			assertThat(responses).hasSize(2);
+			assertThat(responses)
+				.allSatisfy(response -> assertThat(response.hobbies()).hasSize(2));
+			then(profileRepository).should().findAllWithHobbiesByMemberIdIn(memberIds);
+		}
+
+		@Test
+		@DisplayName("bulk 프로필 조회 결과가 비어 있으면 취미 초기화 쿼리를 실행하지 않는다")
+		void shouldSkipHobbyFetchWhenBulkProfilesEmpty() {
+			// given
+			List<Long> memberIds = List.of(1L, 2L);
+			given(profileRepository.findAllByMemberIdIn(memberIds)).willReturn(List.of());
+
+			// when
+			List<ProfileResponse> responses = profileService.getProfilesByIds(memberIds);
+
+			// then
+			assertThat(responses).isEmpty();
+			then(profileRepository).should(never()).findAllWithHobbiesByMemberIdIn(anyList());
+		}
 	}
 
 	private Member createMember(Long memberId) {
-		return Member.builder()
+		Member member = Member.builder()
 			.email("test@test.com")
 			.password("1234")
 			.role(MemberRole.ROLE_GUEST)
 			.status(MemberStatus.ACTIVE)
 			.build();
+		ReflectionTestUtils.setField(member, "id", memberId);
+		return member;
 	}
 
 	private Profile createProfileWithTags(Long memberId) {


### PR DESCRIPTION
## 개요
bulk profile 조회 응답 변환에서 `hobbies` lazy collection이 프로필별로 추가 조회되는 병목을 줄이기 위해, 응답 변환 전에 hobbies를 한 번의 bulk fetch query로 초기화합니다.

Closes #45

@codex

## 변경 사항
- `ProfileRepository`에 hobbies 전용 bulk fetch join query를 추가했습니다.
- `ProfileServiceImpl#getProfilesByIds`에서 member/tags 조회 후 hobbies를 별도 쿼리로 초기화하도록 변경했습니다.
- `tags`와 `hobbies`를 같은 JPQL에서 동시에 fetch join하지 않아 Hibernate multiple bag fetch 문제를 피했습니다.
- bulk 조회 시 hobbies 초기화 쿼리 호출 여부를 검증하는 단위 테스트를 추가했습니다.

## 테스트
- [x] 테스트를 실행했습니다. `./gradlew :user-service:test`
- [x] 테스트를 실행했습니다. `./gradlew test`
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- 성능 리뷰 Finding 3: `ProfileRepository.findAllByMemberIdIn` bulk profile 조회에서 hobbies lazy load가 응답 변환 시 추가 쿼리를 유발할 수 있음
