### PR TITLE
feat(chat): add room user summaries

### DIFF
--- a/chat-service/src/main/java/com/comatching/chat/ChatServiceApplication.java
+++ b/chat-service/src/main/java/com/comatching/chat/ChatServiceApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication(
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.ComponentScan;
 	}
 )
 @ComponentScan(basePackages = {"com.comatching.chat", "com.comatching.common"})
+@EnableFeignClients(basePackages = "com.comatching.chat")
 public class ChatServiceApplication {
 
 	public static void main(String[] args) {

--- a/chat-service/src/main/java/com/comatching/chat/domain/dto/ChatRoomResponse.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/dto/ChatRoomResponse.java
@@ -3,17 +3,24 @@ package com.comatching.chat.domain.dto;
 import java.time.LocalDateTime;
 
 import com.comatching.chat.domain.entity.ChatRoom;
+import com.comatching.common.domain.vo.KoreanAge;
+import com.comatching.common.dto.member.ProfileResponse;
 
 public record ChatRoomResponse(
 	String id,
 	Long matchingId,
 	Long initiatorUserId,
 	Long targetUserId,
+	UserSummary otherUser,
 	String lastMessage,
 	LocalDateTime lastMessageTime,
 	long unreadCount
 ) {
 	public static ChatRoomResponse from(ChatRoom room, long unreadCount) {
+		return from(room, unreadCount, null);
+	}
+
+	public static ChatRoomResponse from(ChatRoom room, long unreadCount, UserSummary otherUser) {
 		String content = (room.getLastMessageInfo() != null) ? room.getLastMessageInfo().getContent() : null;
 		LocalDateTime time = (room.getLastMessageInfo() != null) ? room.getLastMessageInfo().getSentAt() : null;
 
@@ -22,9 +29,33 @@ public record ChatRoomResponse(
 			room.getMatchingId(),
 			room.getInitiatorUserId(),
 			room.getTargetUserId(),
+			otherUser,
 			content,
 			time,
 			unreadCount
 		);
+	}
+
+	public record UserSummary(
+		Long memberId,
+		String nickname,
+		String profileImageUrl,
+		String university,
+		Integer age
+	) {
+		public static UserSummary from(ProfileResponse profile) {
+			KoreanAge age = KoreanAge.fromBirthDate(profile.birthDate());
+			return new UserSummary(
+				profile.memberId(),
+				profile.nickname(),
+				profile.profileImageUrl(),
+				profile.university(),
+				age != null ? age.getValue() : null
+			);
+		}
+
+		public static UserSummary memberOnly(Long memberId) {
+			return new UserSummary(memberId, null, null, null, null);
+		}
 	}
 }

--- a/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImpl.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImpl.java
@@ -4,18 +4,23 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.comatching.chat.domain.dto.ChatRoomResponse;
+import com.comatching.chat.domain.dto.ChatRoomResponse.UserSummary;
 import com.comatching.chat.domain.entity.ChatRoom;
 import com.comatching.chat.domain.repository.ChatMessageRepository;
 import com.comatching.chat.domain.repository.ChatRoomRepository;
 import com.comatching.chat.domain.repository.UnreadCountCondition;
 import com.comatching.chat.domain.service.block.BlockService;
+import com.comatching.chat.infra.client.MemberClient;
 import com.comatching.common.dto.event.matching.MatchingSuccessEvent;
+import com.comatching.common.dto.member.ProfileResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +34,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatMessageRepository chatMessageRepository;
 	private final BlockService blockService;
+	private final MemberClient memberClient;
 
 	@Override
 	public void createChatRoom(MatchingSuccessEvent event) {
@@ -62,9 +68,14 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 			.toList();
 
 		Map<String, Long> unreadCountsByRoom = getUnreadCountsByRoom(visibleRooms, memberId);
+		Map<Long, ProfileResponse> profilesByMemberId = getProfilesByMemberId(visibleRooms, memberId);
 
 		return visibleRooms.stream()
-			.map(room -> ChatRoomResponse.from(room, unreadCountsByRoom.getOrDefault(room.getId(), 0L)))
+			.map(room -> {
+				Long otherUserId = getOtherUserId(room, memberId);
+				UserSummary otherUser = toUserSummary(otherUserId, profilesByMemberId.get(otherUserId));
+				return ChatRoomResponse.from(room, unreadCountsByRoom.getOrDefault(room.getId(), 0L), otherUser);
+			})
 			.toList();
 	}
 
@@ -104,6 +115,32 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 			.toList();
 
 		return chatMessageRepository.countUnreadMessagesByRoom(unreadCountConditions, memberId);
+	}
+
+	private Map<Long, ProfileResponse> getProfilesByMemberId(List<ChatRoom> rooms, Long memberId) {
+		if (rooms.isEmpty()) {
+			return Map.of();
+		}
+
+		List<Long> otherUserIds = rooms.stream()
+			.map(room -> getOtherUserId(room, memberId))
+			.distinct()
+			.toList();
+
+		List<ProfileResponse> profiles = memberClient.getProfiles(otherUserIds);
+		if (profiles == null || profiles.isEmpty()) {
+			return Map.of();
+		}
+
+		return profiles.stream()
+			.collect(Collectors.toMap(ProfileResponse::memberId, Function.identity(), (left, right) -> left));
+	}
+
+	private UserSummary toUserSummary(Long memberId, ProfileResponse profile) {
+		if (profile == null) {
+			return UserSummary.memberOnly(memberId);
+		}
+		return UserSummary.from(profile);
 	}
 
 	private LocalDateTime getMyLastReadAt(ChatRoom room, Long memberId) {

--- a/chat-service/src/main/java/com/comatching/chat/infra/client/MemberClient.java
+++ b/chat-service/src/main/java/com/comatching/chat/infra/client/MemberClient.java
@@ -1,0 +1,16 @@
+package com.comatching.chat.infra.client;
+
+import java.util.List;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.comatching.common.dto.member.ProfileResponse;
+
+@FeignClient(name = "user-service", path = "/api/internal/users", url = "${user-service.url}")
+public interface MemberClient {
+
+	@PostMapping("/profiles/bulk")
+	List<ProfileResponse> getProfiles(@RequestBody List<Long> memberIds);
+}

--- a/chat-service/src/main/resources/application-aws.yml
+++ b/chat-service/src/main/resources/application-aws.yml
@@ -2,6 +2,9 @@
 server:
   port: 9003
 
+user-service:
+  url: http://user-service:9000
+
 spring:
   application:
     name: chat-service

--- a/chat-service/src/main/resources/application.yml
+++ b/chat-service/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 server:
   port: 9003
 
+user-service:
+  url: http://localhost:9000
+
 spring:
   application:
     name: chat-service

--- a/chat-service/src/test/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImplTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,8 @@ import com.comatching.chat.domain.repository.ChatMessageRepository;
 import com.comatching.chat.domain.repository.ChatRoomRepository;
 import com.comatching.chat.domain.repository.UnreadCountCondition;
 import com.comatching.chat.domain.service.block.BlockService;
+import com.comatching.chat.infra.client.MemberClient;
+import com.comatching.common.dto.member.ProfileResponse;
 
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceImplTest {
@@ -40,6 +43,9 @@ class ChatRoomServiceImplTest {
 
 	@Mock
 	private BlockService blockService;
+
+	@Mock
+	private MemberClient memberClient;
 
 	@InjectMocks
 	private ChatRoomServiceImpl chatRoomService;
@@ -58,6 +64,11 @@ class ChatRoomServiceImplTest {
 		given(blockService.getBlockedUserIds(MEMBER_ID)).willReturn(Set.of());
 		given(chatMessageRepository.countUnreadMessagesByRoom(anyList(), eq(MEMBER_ID)))
 			.willReturn(Map.of("room-1", 2L, "room-2", 3L));
+		given(memberClient.getProfiles(anyList()))
+			.willReturn(List.of(
+				profile(OTHER_MEMBER_ID, "첫번째상대", "https://img.example/first.png", "코매칭대", LocalDate.now().minusYears(23)),
+				profile(SECOND_OTHER_MEMBER_ID, "두번째상대", "https://img.example/second.png", "매칭대", LocalDate.now().minusYears(24))
+			));
 
 		// when
 		List<ChatRoomResponse> result = chatRoomService.getMyChatRooms(MEMBER_ID);
@@ -65,12 +76,47 @@ class ChatRoomServiceImplTest {
 		// then
 		assertThat(result).extracting(ChatRoomResponse::unreadCount)
 			.containsExactly(2L, 3L);
+		ChatRoomResponse.UserSummary firstOtherUser = result.get(0).otherUser();
+		assertThat(firstOtherUser.memberId()).isEqualTo(OTHER_MEMBER_ID);
+		assertThat(firstOtherUser.nickname()).isEqualTo("첫번째상대");
+		assertThat(firstOtherUser.profileImageUrl()).isEqualTo("https://img.example/first.png");
+		assertThat(firstOtherUser.university()).isEqualTo("코매칭대");
+		assertThat(firstOtherUser.age()).isEqualTo(24);
 		then(chatMessageRepository).should().countUnreadMessagesByRoom(
 			argThat(conditions -> containsCondition(conditions, "room-1", firstReadAt)
 				&& containsCondition(conditions, "room-2", secondReadAt)),
 			eq(MEMBER_ID)
 		);
+		then(memberClient).should().getProfiles(List.of(OTHER_MEMBER_ID, SECOND_OTHER_MEMBER_ID));
 		then(chatMessageRepository).should(never()).countUnreadMessages(anyString(), any(), anyLong());
+	}
+
+	@Test
+	@DisplayName("채팅방 목록에서 차단된 상대는 프로필 조회 대상에서 제외한다")
+	void getMyChatRooms_excludesBlockedRoomsFromProfileLookup() {
+		// given
+		LocalDateTime firstReadAt = LocalDateTime.of(2026, 1, 1, 12, 0);
+		LocalDateTime blockedReadAt = LocalDateTime.of(2026, 1, 1, 13, 0);
+		ChatRoom visibleRoom = chatRoom("room-1", 100L, MEMBER_ID, OTHER_MEMBER_ID, firstReadAt);
+		ChatRoom blockedRoom = chatRoom("room-2", 101L, MEMBER_ID, SECOND_OTHER_MEMBER_ID, blockedReadAt);
+
+		given(chatRoomRepository.findMyChatRooms(eq(MEMBER_ID), any(Sort.class)))
+			.willReturn(List.of(visibleRoom, blockedRoom));
+		given(blockService.getBlockedUserIds(MEMBER_ID)).willReturn(Set.of(SECOND_OTHER_MEMBER_ID));
+		given(chatMessageRepository.countUnreadMessagesByRoom(anyList(), eq(MEMBER_ID)))
+			.willReturn(Map.of("room-1", 7L));
+		given(memberClient.getProfiles(anyList()))
+			.willReturn(List.of(
+				profile(OTHER_MEMBER_ID, "보이는상대", "https://img.example/visible.png", "코매칭대", LocalDate.now().minusYears(22))
+			));
+
+		// when
+		List<ChatRoomResponse> result = chatRoomService.getMyChatRooms(MEMBER_ID);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).otherUser().memberId()).isEqualTo(OTHER_MEMBER_ID);
+		then(memberClient).should().getProfiles(List.of(OTHER_MEMBER_ID));
 	}
 
 	@Test
@@ -112,6 +158,22 @@ class ChatRoomServiceImplTest {
 		ReflectionTestUtils.setField(room, "id", id);
 		ReflectionTestUtils.setField(room, "initiatorLastReadAt", readAt);
 		return room;
+	}
+
+	private ProfileResponse profile(
+		Long memberId,
+		String nickname,
+		String profileImageUrl,
+		String university,
+		LocalDate birthDate
+	) {
+		return ProfileResponse.builder()
+			.memberId(memberId)
+			.nickname(nickname)
+			.profileImageUrl(profileImageUrl)
+			.university(university)
+			.birthDate(birthDate)
+			.build();
 	}
 
 	private boolean containsCondition(List<UnreadCountCondition> conditions, String roomId, LocalDateTime lastReadAt) {


### PR DESCRIPTION
## 개요
채팅방 목록 응답에 상대방 요약 정보를 포함합니다.

@codex

## 변경 사항
- chat-service에 user-service bulk profile Feign client를 추가했습니다.
- ChatRoomResponse에 otherUser 요약 정보를 추가했습니다.
- 차단된 채팅방을 제외한 뒤 상대 프로필과 안 읽은 메시지 수를 함께 조회합니다.

## 테스트
- [x] 테스트를 실행했습니다. `./gradlew :chat-service:test --tests com.comatching.chat.domain.service.chatroom.ChatRoomServiceImplTest`
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- Stacked PR입니다. Base: `feat/product-catalog-bundle` (#50)