### PR TITLE
chore(gateway): sanitize member headers

### DIFF
--- a/gateway-service/src/main/java/com/comatching/gateway/filter/AuthorizationHeaderFilter.java
+++ b/gateway-service/src/main/java/com/comatching/gateway/filter/AuthorizationHeaderFilter.java
@@ -60,14 +60,21 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
 			try {
 				Claims claims = jwtUtil.parseToken(accessToken);
 				ServerHttpRequest.Builder requestBuilder = request.mutate()
-					.header("X-Member-Id", claims.getSubject())
-					.header("X-Member-Email", claims.get("email", String.class))
-					.header("X-Member-Role", claims.get("role", String.class));
+					.headers(headers -> {
+						headers.remove("X-Member-Id");
+						headers.remove("X-Member-Email");
+						headers.remove("X-Member-Role");
+						headers.remove("X-Member-Nickname");
+
+						headers.set("X-Member-Id", claims.getSubject());
+						headers.set("X-Member-Email", claims.get("email", String.class));
+						headers.set("X-Member-Role", claims.get("role", String.class));
+					});
 
 				String nickname = claims.get("nickname", String.class);
 				if (nickname != null && !nickname.isBlank()) {
-					nickname = URLEncoder.encode(nickname, StandardCharsets.UTF_8);
-					requestBuilder.header("X-Member-Nickname", nickname);
+					String encodedNickname = URLEncoder.encode(nickname, StandardCharsets.UTF_8);
+					requestBuilder.headers(headers -> headers.set("X-Member-Nickname", encodedNickname));
 				}
 
 				return chain.filter(exchange.mutate().request(requestBuilder.build()).build());

--- a/gateway-service/src/main/resources/application-aws.yml
+++ b/gateway-service/src/main/resources/application-aws.yml
@@ -18,7 +18,7 @@ spring:
                   - "https://comatching.site"
                   - "http://localhost:3000"
                   - "http://localhost:5173"
-                allowedMethods: [GET, POST, PUT, DELETE, OPTIONS]
+                allowedMethods: [GET, POST, PUT, PATCH, DELETE, OPTIONS]
                 allowedHeaders: "*"
                 allowCredentials: true
 

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
                   - "http://localhost:3000"
                   - "http://localhost:5173"
                   - "http://localhost:5500"
-                allowedMethods: [GET, POST, PUT, DELETE, OPTIONS]
+                allowedMethods: [GET, POST, PUT, PATCH, DELETE, OPTIONS]
                 allowedHeaders: "*"
                 allowCredentials: true
 

--- a/gateway-service/src/test/java/com/comatching/gateway/filter/AuthorizationHeaderFilterTest.java
+++ b/gateway-service/src/test/java/com/comatching/gateway/filter/AuthorizationHeaderFilterTest.java
@@ -1,0 +1,60 @@
+package com.comatching.gateway.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+import com.comatching.common.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import reactor.core.publisher.Mono;
+
+class AuthorizationHeaderFilterTest {
+
+	private static final String SECRET_KEY =
+		"c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK";
+
+	private final JwtUtil jwtUtil = new JwtUtil(SECRET_KEY, 3600000L, 3600000L);
+	private final AuthorizationHeaderFilter filter = new AuthorizationHeaderFilter(jwtUtil, new ObjectMapper());
+
+	@Test
+	void shouldReplaceClientMemberHeadersWithTokenClaims() {
+		String accessToken = jwtUtil.createAccessToken(
+			1L,
+			"admin@comatching.com",
+			"ROLE_ADMIN",
+			"ACTIVE",
+			"관리자"
+		);
+		MockServerHttpRequest request = MockServerHttpRequest.get("/api/v1/admin/users")
+			.cookie(new HttpCookie("accessToken", accessToken))
+			.header("X-Member-Id", "999")
+			.header("X-Member-Email", "user@comatching.com")
+			.header("X-Member-Role", "ROLE_USER")
+			.header("X-Member-Nickname", "stale")
+			.build();
+		MockServerWebExchange exchange = MockServerWebExchange.from(request);
+		AtomicReference<ServerHttpRequest> downstreamRequest = new AtomicReference<>();
+		GatewayFilter gatewayFilter = filter.apply(new AuthorizationHeaderFilter.Config());
+
+		gatewayFilter.filter(exchange, filteredExchange -> {
+			downstreamRequest.set(filteredExchange.getRequest());
+			return Mono.empty();
+		}).block();
+
+		ServerHttpRequest mutatedRequest = downstreamRequest.get();
+		assertThat(mutatedRequest.getHeaders().get("X-Member-Id")).containsExactly("1");
+		assertThat(mutatedRequest.getHeaders().get("X-Member-Email")).containsExactly("admin@comatching.com");
+		assertThat(mutatedRequest.getHeaders().get("X-Member-Role")).containsExactly("ROLE_ADMIN");
+		assertThat(mutatedRequest.getHeaders().get("X-Member-Nickname")).containsExactly(
+			"%EA%B4%80%EB%A6%AC%EC%9E%90"
+		);
+	}
+}


### PR DESCRIPTION
## 개요
게이트웨이에서 외부가 보낸 회원 헤더를 제거하고 JWT claims 기반 헤더로 재설정합니다.

@codex

## 변경 사항
- 기존 X-Member-* 헤더를 제거한 뒤 토큰 claims로 재주입합니다.
- 닉네임 헤더는 인코딩 후 set 방식으로 설정합니다.
- CORS 허용 메서드에 PATCH를 추가했습니다.
- 헤더 덮어쓰기 회귀 테스트를 추가했습니다.

## 테스트
- [x] 테스트를 실행했습니다. `./gradlew :gateway-service:test --tests com.comatching.gateway.filter.AuthorizationHeaderFilterTest`
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- Stacked PR입니다. Base: `feat/product-catalog-bundle` (#50)