### PR TITLE
feat(item): add admin notice list

### DIFF
--- a/item-service/src/main/java/com/comatching/item/domain/notice/dto/AdminNoticeResponse.java
+++ b/item-service/src/main/java/com/comatching/item/domain/notice/dto/AdminNoticeResponse.java
@@ -1,0 +1,29 @@
+package com.comatching.item.domain.notice.dto;
+
+import java.time.LocalDateTime;
+
+import com.comatching.item.domain.notice.entity.Notice;
+
+public record AdminNoticeResponse(
+	Long noticeId,
+	String title,
+	String content,
+	LocalDateTime startTime,
+	LocalDateTime endTime,
+	boolean active
+) {
+	public static AdminNoticeResponse from(Notice notice, LocalDateTime currentTime) {
+		return new AdminNoticeResponse(
+			notice.getId(),
+			notice.getTitle(),
+			notice.getContent(),
+			notice.getStartTime(),
+			notice.getEndTime(),
+			isActive(notice, currentTime)
+		);
+	}
+
+	private static boolean isActive(Notice notice, LocalDateTime currentTime) {
+		return !notice.getStartTime().isAfter(currentTime) && !notice.getEndTime().isBefore(currentTime);
+	}
+}

--- a/item-service/src/main/java/com/comatching/item/domain/notice/repository/NoticeRepository.java
+++ b/item-service/src/main/java/com/comatching/item/domain/notice/repository/NoticeRepository.java
@@ -9,6 +9,8 @@ import com.comatching.item.domain.notice.entity.Notice;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
+	List<Notice> findAllByOrderByStartTimeDescIdDesc();
+
 	List<Notice> findAllByStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeDescIdDesc(
 		LocalDateTime currentTime,
 		LocalDateTime currentTime2

--- a/item-service/src/main/java/com/comatching/item/domain/notice/service/NoticeService.java
+++ b/item-service/src/main/java/com/comatching/item/domain/notice/service/NoticeService.java
@@ -2,6 +2,7 @@ package com.comatching.item.domain.notice.service;
 
 import java.util.List;
 
+import com.comatching.item.domain.notice.dto.AdminNoticeResponse;
 import com.comatching.item.domain.notice.dto.ActiveNoticeResponse;
 import com.comatching.item.domain.notice.dto.NoticeCreateRequest;
 import com.comatching.item.domain.notice.dto.NoticeUpdateRequest;
@@ -15,4 +16,6 @@ public interface NoticeService {
 	void deleteNotice(Long noticeId);
 
 	List<ActiveNoticeResponse> getActiveNotices();
+
+	List<AdminNoticeResponse> getAdminNotices();
 }

--- a/item-service/src/main/java/com/comatching/item/domain/notice/service/NoticeServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/notice/service/NoticeServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.comatching.common.exception.BusinessException;
 import com.comatching.common.exception.code.GeneralErrorCode;
+import com.comatching.item.domain.notice.dto.AdminNoticeResponse;
 import com.comatching.item.domain.notice.dto.ActiveNoticeResponse;
 import com.comatching.item.domain.notice.dto.NoticeCreateRequest;
 import com.comatching.item.domain.notice.dto.NoticeUpdateRequest;
@@ -59,6 +60,16 @@ public class NoticeServiceImpl implements NoticeService {
 			.findAllByStartTimeLessThanEqualAndEndTimeGreaterThanEqualOrderByStartTimeDescIdDesc(currentTime, currentTime)
 			.stream()
 			.map(ActiveNoticeResponse::from)
+			.toList();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<AdminNoticeResponse> getAdminNotices() {
+		LocalDateTime currentTime = LocalDateTime.now();
+		return noticeRepository.findAllByOrderByStartTimeDescIdDesc()
+			.stream()
+			.map(notice -> AdminNoticeResponse.from(notice, currentTime))
 			.toList();
 	}
 

--- a/item-service/src/main/java/com/comatching/item/infra/controller/NoticeController.java
+++ b/item-service/src/main/java/com/comatching/item/infra/controller/NoticeController.java
@@ -17,6 +17,7 @@ import com.comatching.common.annotation.RequireRole;
 import com.comatching.common.domain.enums.MemberRole;
 import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.response.ApiResponse;
+import com.comatching.item.domain.notice.dto.AdminNoticeResponse;
 import com.comatching.item.domain.notice.dto.ActiveNoticeResponse;
 import com.comatching.item.domain.notice.dto.NoticeCreateRequest;
 import com.comatching.item.domain.notice.dto.NoticeUpdateRequest;
@@ -34,6 +35,15 @@ import lombok.RequiredArgsConstructor;
 public class NoticeController {
 
 	private final NoticeService noticeService;
+
+	@RequireRole(MemberRole.ROLE_ADMIN)
+	@Operation(summary = "관리자 공지사항 목록 조회", description = "관리자가 등록된 전체 공지사항을 노출 시작시간 내림차순으로 조회합니다.")
+	@GetMapping("/admin/notices")
+	public ResponseEntity<ApiResponse<List<AdminNoticeResponse>>> getAdminNotices(
+		@CurrentMember MemberInfo memberInfo
+	) {
+		return ResponseEntity.ok(ApiResponse.ok(noticeService.getAdminNotices()));
+	}
 
 	@RequireRole(MemberRole.ROLE_ADMIN)
 	@Operation(summary = "공지사항 등록", description = "관리자가 제목, 내용, 시작시간, 종료시간으로 공지사항을 등록합니다.")

--- a/item-service/src/test/java/com/comatching/item/domain/notice/service/NoticeServiceImplTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/notice/service/NoticeServiceImplTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.comatching.common.exception.BusinessException;
 import com.comatching.common.exception.code.GeneralErrorCode;
+import com.comatching.item.domain.notice.dto.AdminNoticeResponse;
 import com.comatching.item.domain.notice.dto.ActiveNoticeResponse;
 import com.comatching.item.domain.notice.dto.NoticeCreateRequest;
 import com.comatching.item.domain.notice.dto.NoticeUpdateRequest;
@@ -120,6 +121,40 @@ class NoticeServiceImplTest {
 		assertThat(responses.get(0).noticeId()).isEqualTo(10L);
 		assertThat(responses.get(0).title()).isEqualTo("공지 제목");
 		assertThat(responses.get(0).content()).isEqualTo("한 줄\n두 줄");
+	}
+
+	@Test
+	@DisplayName("관리자 공지사항 목록 조회 시 전체 공지사항과 활성 여부를 반환한다")
+	void shouldReturnAdminNotices() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		Notice activeNotice = Notice.builder()
+			.title("활성 공지")
+			.content("활성 내용")
+			.startTime(now.minusDays(1))
+			.endTime(now.plusDays(1))
+			.build();
+		ReflectionTestUtils.setField(activeNotice, "id", 11L);
+
+		Notice expiredNotice = Notice.builder()
+			.title("종료 공지")
+			.content("종료 내용")
+			.startTime(now.minusDays(3))
+			.endTime(now.minusDays(2))
+			.build();
+		ReflectionTestUtils.setField(expiredNotice, "id", 12L);
+
+		given(noticeRepository.findAllByOrderByStartTimeDescIdDesc())
+			.willReturn(List.of(activeNotice, expiredNotice));
+
+		// when
+		List<AdminNoticeResponse> responses = noticeService.getAdminNotices();
+
+		// then
+		assertThat(responses).hasSize(2);
+		assertThat(responses).extracting(AdminNoticeResponse::noticeId).containsExactly(11L, 12L);
+		assertThat(responses).extracting(AdminNoticeResponse::title).containsExactly("활성 공지", "종료 공지");
+		assertThat(responses).extracting(AdminNoticeResponse::active).containsExactly(true, false);
 	}
 
 	@Test


### PR DESCRIPTION
## 개요
관리자가 전체 공지사항과 활성 여부를 조회할 수 있는 목록 API를 추가합니다.

@codex

## 변경 사항
- 관리자 공지사항 목록 응답 DTO를 추가했습니다.
- 전체 공지사항을 노출 시작시간/ID 내림차순으로 조회합니다.
- `/api/v1/admin/notices` GET API를 추가했습니다.
- 활성/종료 공지 응답 테스트를 추가했습니다.

## 테스트
- [x] 테스트를 실행했습니다. `./gradlew :item-service:test --tests com.comatching.item.domain.notice.service.NoticeServiceImplTest`
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- Stacked PR입니다. Base: `feat/product-catalog-bundle` (#50)