### PR TITLE
feat(item): enforce purchase limits

### DIFF
--- a/item-service/src/main/java/com/comatching/item/domain/order/repository/OrderRepository.java
+++ b/item-service/src/main/java/com/comatching/item/domain/order/repository/OrderRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.comatching.common.domain.enums.ItemType;
 import com.comatching.item.domain.order.entity.Order;
 import com.comatching.item.domain.order.enums.OrderStatus;
 
@@ -22,6 +23,21 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 		AND o.expiresAt > :now
 		""")
 	boolean existsActivePendingOrder(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
+
+	@Query("""
+		SELECT COALESCE(SUM(oi.quantity), 0)
+		FROM Order o
+		JOIN o.orderItems oi
+		WHERE o.memberId = :memberId
+		AND o.status = com.comatching.item.domain.order.enums.OrderStatus.PENDING
+		AND o.expiresAt > :now
+		AND oi.itemType = :itemType
+		""")
+	long sumActivePendingQuantityByMemberIdAndItemType(
+		@Param("memberId") Long memberId,
+		@Param("itemType") ItemType itemType,
+		@Param("now") LocalDateTime now
+	);
 
 	List<Order> findAllByStatusOrderByRequestedAtDesc(OrderStatus status);
 

--- a/item-service/src/main/java/com/comatching/item/domain/product/dto/PurchaseLimitResponse.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/dto/PurchaseLimitResponse.java
@@ -1,0 +1,37 @@
+package com.comatching.item.domain.product.dto;
+
+import java.util.List;
+
+import com.comatching.common.domain.enums.ItemType;
+
+public record PurchaseLimitResponse(
+	List<ItemPurchaseLimitResponse> limits
+) {
+	public record ItemPurchaseLimitResponse(
+		ItemType itemType,
+		String itemName,
+		long ownedQuantity,
+		long pendingQuantity,
+		int maxQuantity,
+		long remainingQuantity,
+		boolean purchasable
+	) {
+		public static ItemPurchaseLimitResponse of(
+			ItemType itemType,
+			long ownedQuantity,
+			long pendingQuantity,
+			int maxQuantity
+		) {
+			long remainingQuantity = Math.max(0, maxQuantity - ownedQuantity - pendingQuantity);
+			return new ItemPurchaseLimitResponse(
+				itemType,
+				itemType.getName(),
+				ownedQuantity,
+				pendingQuantity,
+				maxQuantity,
+				remainingQuantity,
+				remainingQuantity > 0
+			);
+		}
+	}
+}

--- a/item-service/src/main/java/com/comatching/item/domain/product/service/ShopService.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/service/ShopService.java
@@ -3,6 +3,7 @@ package com.comatching.item.domain.product.service;
 import java.util.List;
 
 import com.comatching.item.domain.product.dto.ProductResponse;
+import com.comatching.item.domain.product.dto.PurchaseLimitResponse;
 import com.comatching.item.domain.product.dto.PurchasePendingStatusResponse;
 
 public interface ShopService {
@@ -12,4 +13,6 @@ public interface ShopService {
 	void requestPurchase(Long memberId, Long productId);
 
 	PurchasePendingStatusResponse getMyPurchaseRequestStatus(Long memberId);
+
+	PurchaseLimitResponse getMyPurchaseLimits(Long memberId);
 }

--- a/item-service/src/main/java/com/comatching/item/domain/product/service/ShopServiceImpl.java
+++ b/item-service/src/main/java/com/comatching/item/domain/product/service/ShopServiceImpl.java
@@ -1,22 +1,28 @@
 package com.comatching.item.domain.product.service;
 
 import java.time.LocalDateTime;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.comatching.common.annotation.DistributedLock;
+import com.comatching.common.domain.enums.ItemType;
 import com.comatching.common.dto.member.OrdererInfoDto;
 import com.comatching.common.exception.BusinessException;
+import com.comatching.item.domain.item.repository.ItemRepository;
 import com.comatching.item.domain.order.entity.Order;
 import com.comatching.item.domain.order.entity.OrderItem;
 import com.comatching.item.domain.order.repository.OrderRepository;
 import com.comatching.item.domain.order.service.OrderOutboxService;
 import com.comatching.item.domain.product.dto.ProductResponse;
+import com.comatching.item.domain.product.dto.PurchaseLimitResponse;
 import com.comatching.item.domain.product.dto.PurchasePendingStatusResponse;
 import com.comatching.item.domain.product.entity.Product;
+import com.comatching.item.domain.product.entity.ProductReward;
 import com.comatching.item.domain.product.repository.ProductRepository;
 import com.comatching.item.global.exception.ItemErrorCode;
 import com.comatching.item.global.exception.PaymentErrorCode;
@@ -30,9 +36,18 @@ import lombok.RequiredArgsConstructor;
 public class ShopServiceImpl implements ShopService {
 
 	private static final int ORDER_EXPIRE_MINUTES = 10;
+	private static final Map<ItemType, Integer> PURCHASE_LIMITS = Map.of(
+		ItemType.MATCHING_TICKET, 30,
+		ItemType.OPTION_TICKET, 90
+	);
+	private static final List<ItemType> LIMITED_ITEM_TYPES = List.of(
+		ItemType.MATCHING_TICKET,
+		ItemType.OPTION_TICKET
+	);
 
 	private final ProductRepository productRepository;
 	private final OrderRepository orderRepository;
+	private final ItemRepository itemRepository;
 	private final UserOrderClient userOrderClient;
 	private final OrderOutboxService orderOutboxService;
 
@@ -61,6 +76,8 @@ public class ShopServiceImpl implements ShopService {
 		if (hasPendingRequest) {
 			throw new BusinessException(PaymentErrorCode.PENDING_REQUEST_ALREADY_EXISTS);
 		}
+
+		validatePurchaseLimit(memberId, product, now);
 
 		OrdererInfoDto ordererInfo = userOrderClient.getOrdererInfo(memberId);
 		String realName = normalizeRequiredText(ordererInfo.realName(), PaymentErrorCode.REAL_NAME_REQUIRED);
@@ -93,6 +110,48 @@ public class ShopServiceImpl implements ShopService {
 	public PurchasePendingStatusResponse getMyPurchaseRequestStatus(Long memberId) {
 		boolean hasPendingRequest = orderRepository.existsActivePendingOrder(memberId, LocalDateTime.now());
 		return hasPendingRequest ? PurchasePendingStatusResponse.pending() : PurchasePendingStatusResponse.none();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PurchaseLimitResponse getMyPurchaseLimits(Long memberId) {
+		LocalDateTime now = LocalDateTime.now();
+		return new PurchaseLimitResponse(
+			LIMITED_ITEM_TYPES.stream()
+				.map(itemType -> PurchaseLimitResponse.ItemPurchaseLimitResponse.of(
+					itemType,
+					itemRepository.sumUsableQuantityByMemberIdAndItemType(memberId, itemType),
+					orderRepository.sumActivePendingQuantityByMemberIdAndItemType(memberId, itemType, now),
+					PURCHASE_LIMITS.get(itemType)
+				))
+				.toList()
+		);
+	}
+
+	private void validatePurchaseLimit(Long memberId, Product product, LocalDateTime now) {
+		Map<ItemType, Integer> requestedQuantityByType = getRequestedQuantityByType(product);
+
+		for (ItemType itemType : LIMITED_ITEM_TYPES) {
+			int requestedQuantity = requestedQuantityByType.getOrDefault(itemType, 0);
+			if (requestedQuantity == 0) {
+				continue;
+			}
+
+			long ownedQuantity = itemRepository.sumUsableQuantityByMemberIdAndItemType(memberId, itemType);
+			long pendingQuantity = orderRepository.sumActivePendingQuantityByMemberIdAndItemType(memberId, itemType, now);
+			int maxQuantity = PURCHASE_LIMITS.get(itemType);
+			if (ownedQuantity + pendingQuantity + requestedQuantity > maxQuantity) {
+				throw new BusinessException(PaymentErrorCode.PURCHASE_LIMIT_EXCEEDED);
+			}
+		}
+	}
+
+	private Map<ItemType, Integer> getRequestedQuantityByType(Product product) {
+		Map<ItemType, Integer> requestedQuantityByType = new EnumMap<>(ItemType.class);
+		for (ProductReward reward : product.getRewards()) {
+			requestedQuantityByType.merge(reward.getItemType(), reward.getQuantity(), Integer::sum);
+		}
+		return requestedQuantityByType;
 	}
 
 	private String normalizeRequiredText(String value, PaymentErrorCode errorCode) {

--- a/item-service/src/main/java/com/comatching/item/global/exception/PaymentErrorCode.java
+++ b/item-service/src/main/java/com/comatching/item/global/exception/PaymentErrorCode.java
@@ -19,6 +19,7 @@ public enum PaymentErrorCode implements ErrorCode {
 	INVALID_REQUESTED_PRICE("PAY-008", HttpStatus.BAD_REQUEST, "요청 금액이 서버 계산 금액과 일치하지 않습니다."),
 	ITEM_NAME_REQUIRED("PAY-009", HttpStatus.BAD_REQUEST, "상품명을 입력해주세요."),
 	USERNAME_REQUIRED("PAY-010", HttpStatus.BAD_REQUEST, "사용자명을 입력해주세요."),
+	PURCHASE_LIMIT_EXCEEDED("PAY-011", HttpStatus.BAD_REQUEST, "아이템 구매 한도를 초과했습니다."),
 	;
 
 	private final String code;

--- a/item-service/src/main/java/com/comatching/item/infra/controller/ShopController.java
+++ b/item-service/src/main/java/com/comatching/item/infra/controller/ShopController.java
@@ -14,6 +14,7 @@ import com.comatching.common.annotation.CurrentMember;
 import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.dto.response.ApiResponse;
 import com.comatching.item.domain.product.dto.ProductResponse;
+import com.comatching.item.domain.product.dto.PurchaseLimitResponse;
 import com.comatching.item.domain.product.dto.PurchasePendingStatusResponse;
 import com.comatching.item.domain.product.service.ShopService;
 
@@ -56,5 +57,13 @@ public class ShopController {
 		@CurrentMember MemberInfo memberInfo
 	) {
 		return ResponseEntity.ok(ApiResponse.ok(shopService.getMyPurchaseRequestStatus(memberInfo.memberId())));
+	}
+
+	@Operation(summary = "내 아이템 구매 한도 조회", description = "현재 사용자의 매칭권/옵션권 보유 수량, 진행 중인 구매 요청 수량, 최대 구매 한도와 남은 구매 가능 수량을 조회합니다.")
+	@GetMapping("/purchase/limits")
+	public ResponseEntity<ApiResponse<PurchaseLimitResponse>> getMyPurchaseLimits(
+		@CurrentMember MemberInfo memberInfo
+	) {
+		return ResponseEntity.ok(ApiResponse.ok(shopService.getMyPurchaseLimits(memberInfo.memberId())));
 	}
 }

--- a/item-service/src/test/java/com/comatching/item/domain/product/service/ShopServiceImplTest.java
+++ b/item-service/src/test/java/com/comatching/item/domain/product/service/ShopServiceImplTest.java
@@ -23,10 +23,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.comatching.common.domain.enums.ItemType;
 import com.comatching.common.dto.member.OrdererInfoDto;
 import com.comatching.common.exception.BusinessException;
+import com.comatching.item.domain.item.repository.ItemRepository;
 import com.comatching.item.domain.order.entity.Order;
 import com.comatching.item.domain.order.enums.OrderStatus;
 import com.comatching.item.domain.order.repository.OrderRepository;
 import com.comatching.item.domain.order.service.OrderOutboxService;
+import com.comatching.item.domain.product.dto.PurchaseLimitResponse;
 import com.comatching.item.domain.product.dto.PurchasePendingStatusResponse;
 import com.comatching.item.domain.product.dto.ProductResponse;
 import com.comatching.item.domain.product.entity.Product;
@@ -49,6 +51,9 @@ class ShopServiceImplTest {
 
 	@Mock
 	private OrderRepository orderRepository;
+
+	@Mock
+	private ItemRepository itemRepository;
 
 	@Mock
 	private UserOrderClient userOrderClient;
@@ -175,6 +180,28 @@ class ShopServiceImplTest {
 	}
 
 	@Test
+	@DisplayName("상품 구매 후 아이템 보유 수량이 구매 한도를 초과하면 요청을 막는다")
+	void shouldThrowWhenPurchaseLimitExceeded() {
+		// given
+		Product product = product("매칭권 패키지", 9900, true);
+		product.addReward(ProductReward.builder().itemType(ItemType.MATCHING_TICKET).quantity(10).build());
+		given(productRepository.findById(3L)).willReturn(Optional.of(product));
+		given(orderRepository.existsActivePendingOrder(eq(100L), any())).willReturn(false);
+		given(itemRepository.sumUsableQuantityByMemberIdAndItemType(100L, ItemType.MATCHING_TICKET))
+			.willReturn(25L);
+		given(orderRepository.sumActivePendingQuantityByMemberIdAndItemType(eq(100L), eq(ItemType.MATCHING_TICKET), any()))
+			.willReturn(0L);
+
+		// when & then
+		assertThatThrownBy(() -> shopService.requestPurchase(100L, 3L))
+			.isInstanceOf(BusinessException.class)
+			.extracting(exception -> ((BusinessException)exception).getErrorCode())
+			.isEqualTo(PaymentErrorCode.PURCHASE_LIMIT_EXCEEDED);
+		then(userOrderClient).should(never()).getOrdererInfo(any());
+		then(orderRepository).should(never()).save(any());
+	}
+
+	@Test
 	@DisplayName("회원 실명이 없으면 예외가 발생한다")
 	void shouldThrowWhenRealNameMissing() {
 		// given
@@ -230,6 +257,38 @@ class ShopServiceImplTest {
 
 		// then
 		assertThat(response.status()).isEqualTo("NONE");
+	}
+
+	@Test
+	@DisplayName("내 구매 한도 조회 시 보유 수량, 대기 수량, 최대치와 잔여 수량을 반환한다")
+	void shouldReturnMyPurchaseLimits() {
+		// given
+		given(itemRepository.sumUsableQuantityByMemberIdAndItemType(100L, ItemType.MATCHING_TICKET))
+			.willReturn(12L);
+		given(itemRepository.sumUsableQuantityByMemberIdAndItemType(100L, ItemType.OPTION_TICKET))
+			.willReturn(80L);
+		given(orderRepository.sumActivePendingQuantityByMemberIdAndItemType(eq(100L), eq(ItemType.MATCHING_TICKET), any()))
+			.willReturn(5L);
+		given(orderRepository.sumActivePendingQuantityByMemberIdAndItemType(eq(100L), eq(ItemType.OPTION_TICKET), any()))
+			.willReturn(20L);
+
+		// when
+		PurchaseLimitResponse response = shopService.getMyPurchaseLimits(100L);
+
+		// then
+		assertThat(response.limits()).hasSize(2);
+		assertThat(response.limits().get(0).itemType()).isEqualTo(ItemType.MATCHING_TICKET);
+		assertThat(response.limits().get(0).ownedQuantity()).isEqualTo(12);
+		assertThat(response.limits().get(0).pendingQuantity()).isEqualTo(5);
+		assertThat(response.limits().get(0).maxQuantity()).isEqualTo(30);
+		assertThat(response.limits().get(0).remainingQuantity()).isEqualTo(13);
+		assertThat(response.limits().get(0).purchasable()).isTrue();
+		assertThat(response.limits().get(1).itemType()).isEqualTo(ItemType.OPTION_TICKET);
+		assertThat(response.limits().get(1).ownedQuantity()).isEqualTo(80);
+		assertThat(response.limits().get(1).pendingQuantity()).isEqualTo(20);
+		assertThat(response.limits().get(1).maxQuantity()).isEqualTo(90);
+		assertThat(response.limits().get(1).remainingQuantity()).isZero();
+		assertThat(response.limits().get(1).purchasable()).isFalse();
 	}
 
 	private Product product(String name, int price, boolean isActive) {


### PR DESCRIPTION
## 개요
매칭권/옵션권 구매 한도 조회와 구매 요청 시 한도 초과 검증을 추가합니다.

@codex

## 변경 사항
- 보유 수량과 진행 중인 구매 요청 수량을 합산해 구매 한도를 검증합니다.
- 내 구매 한도 조회 API와 응답 DTO를 추가했습니다.
- 한도 초과 결제 오류 코드를 추가했습니다.
- 구매 한도 검증 및 조회 테스트를 추가했습니다.

## 테스트
- [x] 테스트를 실행했습니다. `./gradlew :item-service:test --tests com.comatching.item.domain.product.service.ShopServiceImplTest`
- [ ] 관련 수동 검증을 완료했습니다.
- [ ] 테스트가 필요 없는 변경입니다.

## 체크리스트
- [x] 브랜치명이 규칙을 따릅니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [ ] 이슈와 PR이 연결되어 있습니다.
- [x] 작업 완료 후 merge 가능한 상태입니다.

## 스크린샷 / 참고 자료
- Stacked PR입니다. Base: `feat/product-catalog-bundle` (#50)