### PR TITLE
feat(matching): 탈퇴 tombstone TTL 정리 배치

### DIFF
--- a/KAFKA_PARTITIONING.md
+++ b/KAFKA_PARTITIONING.md
@@ -183,6 +183,24 @@ concurrency 3 에서 두 이벤트는 실제로 서로 다른 스레드에서 **
   잔존**한다. 잠금 조회는 스냅샷과 무관하게 최신 커밋을 읽어 이 구멍을
   막는다.
 
+#### tombstone TTL — 영구 보존이 만드는 반대 방향의 사고
+
+tombstone 은 늦은 갱신 이벤트가 올 수 있는 동안만 필요하다. 그 상한은
+`profile-updates` 의 retention(브로커 기본 7일)이다 — 그보다 오래된
+이벤트는 토픽에서 소거되어 도착 자체가 불가능하다. 반대로 영구히 남기면
+같은 memberId 로 **재가입**한 회원의 프로필 이벤트가 tombstone 에 걸러져
+영원히 매칭에서 제외된다.
+
+그래서 `WithdrawnMemberCleanupScheduler` 가 매일 04시에 `withdrawnAt` 이
+보존 기간(기본 14일 = retention 의 2배, `matching.tombstone.retention-days`)
+을 넘긴 행을 벌크 삭제한다. 다중 인스턴스에서 겹쳐 돌아도 멱등이라 분산
+락은 두지 않았다.
+
+**운영 제약**: `profile-updates.DLT` 재적재(re-drive)는 반드시 이 보존
+기간 안에 해야 한다. TTL 이후 재적재하면 tombstone 이 이미 지워져 탈퇴
+회원이 부활할 수 있다. retention 을 늘리면 `retention-days` 도 같이
+늘려야 한다.
+
 ### 5. `auto.offset.reset=earliest` — 증설이 유실이 되지 않게
 
 공통 컨슈머 팩토리는 yml 의 `spring.kafka.consumer.*` 를 읽지 않는 수동
@@ -230,6 +248,7 @@ concurrency 3 에서 두 이벤트는 실제로 서로 다른 스레드에서 **
 | 탈퇴 이벤트 재전달·후보 없는 탈퇴 ⇒ 멱등 | 〃 | ✅ |
 | 탈퇴하지 않은 회원의 upsert 는 그대로 동작 (신규 + 갱신) | 〃 | ✅ |
 | **동시 실행**: upsert 가 갭 락을 잡고 진행 중일 때 탈퇴가 끼어들어도 후보가 남지 않음 | 실제 MySQL, 두 스레드·두 트랜잭션으로 교차 재현 | ✅ |
+| TTL 경과 tombstone 만 삭제되고 보존 기간 내 행은 남는다 | 실제 MySQL (`WithdrawnMemberCleanupSchedulerIT`) | ✅ |
 
 user-service · matching-service 전체 테스트 회귀 통과 (failures 0, errors 0).
 구현 후 별도의 다각도 검증(Kafka 의미론·JPA 잠금·운영 설정)을 거쳐 발견된

--- a/KAFKA_PARTITIONING.md
+++ b/KAFKA_PARTITIONING.md
@@ -183,22 +183,47 @@ concurrency 3 에서 두 이벤트는 실제로 서로 다른 스레드에서 **
   잔존**한다. 잠금 조회는 스냅샷과 무관하게 최신 커밋을 읽어 이 구멍을
   막는다.
 
+#### 토픽 retention — 축제 단발성 서비스에 7일은 과하다
+
+`member-withdraw` · `profile-updates` 의 retention 을 브로커 기본 7일에서
+**1일**로 명시했다(`KafkaTopicConfig`, `retention.ms`). 단, "몇 분" 수준까지
+줄이지는 않았다. retention 은 저장 비용이 아니라 **컨슈머가 죽어 있어도
+되는 최대 시간**이기 때문이다.
+
+발행됐지만 아직 소비되지 않은 메시지는 retention 이 지나면 소비 여부와
+무관하게 소거된다. retention 이 컨슈머 다운타임보다 짧으면 그 사이
+발행분이 조용히 사라진다 — 재시도도 DLT 도 개입할 기회가 없는, 이번
+작업이 없애려던 바로 그 조용한 유실이다.
+
+```text
+retention 이 덮어야 하는 창
+  배포 다운타임                 수 분
+  신규 파티션 배정 지연          최대 5분 (earliest 절 참고)
+  차단 재시도 head-of-line      레코드당 최대 7초 × 백로그
+  야간 크래시 → 아침 발견        수 시간   ← 하한을 결정
+```
+
+밤새 장애를 아침에 발견하는 시나리오까지 덮는 하한이 1일이다.
+기존 토픽에도 적용되도록 `KafkaAdmin.setModifyTopicConfigs(true)` 를 켰다
+(NewTopic 에 선언한 config 만 비교·수정하므로 다른 설정에는 무해).
+`.DLT` 토픽은 사람이 열어 보고 재처리하는 곳이라 줄이지 않는다(기본 7일).
+
 #### tombstone TTL — 영구 보존이 만드는 반대 방향의 사고
 
 tombstone 은 늦은 갱신 이벤트가 올 수 있는 동안만 필요하다. 그 상한은
-`profile-updates` 의 retention(브로커 기본 7일)이다 — 그보다 오래된
+`profile-updates` 의 retention(위에서 1일로 명시)이다 — 그보다 오래된
 이벤트는 토픽에서 소거되어 도착 자체가 불가능하다. 반대로 영구히 남기면
 같은 memberId 로 **재가입**한 회원의 프로필 이벤트가 tombstone 에 걸러져
 영원히 매칭에서 제외된다.
 
 그래서 `WithdrawnMemberCleanupScheduler` 가 매일 04시에 `withdrawnAt` 이
-보존 기간(기본 14일 = retention 의 2배, `matching.tombstone.retention-days`)
+보존 기간(기본 2일 = retention 의 2배, `matching.tombstone.retention-days`)
 을 넘긴 행을 벌크 삭제한다. 다중 인스턴스에서 겹쳐 돌아도 멱등이라 분산
 락은 두지 않았다.
 
 **운영 제약**: `profile-updates.DLT` 재적재(re-drive)는 반드시 이 보존
-기간 안에 해야 한다. TTL 이후 재적재하면 tombstone 이 이미 지워져 탈퇴
-회원이 부활할 수 있다. retention 을 늘리면 `retention-days` 도 같이
+기간(2일) 안에 해야 한다. TTL 이후 재적재하면 tombstone 이 이미 지워져
+탈퇴 회원이 부활할 수 있다. retention 을 늘리면 `retention-days` 도 같이
 늘려야 한다.
 
 ### 5. `auto.offset.reset=earliest` — 증설이 유실이 되지 않게

--- a/matching-service/src/main/java/com/comatching/matching/MatchingServiceApplication.java
+++ b/matching-service/src/main/java/com/comatching/matching/MatchingServiceApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = { UserDetailsServiceAutoConfiguration.class })
 @ComponentScan(basePackages = {"com.comatching.matching", "com.comatching.common"})
 @EnableFeignClients(basePackages = "com.comatching.matching")
+@EnableScheduling
 public class MatchingServiceApplication {
 
 	public static void main(String[] args) {

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/WithdrawnMemberRepository.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/WithdrawnMemberRepository.java
@@ -1,9 +1,13 @@
 package com.comatching.matching.domain.repository.candidate;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.comatching.matching.domain.entity.WithdrawnMember;
@@ -23,4 +27,14 @@ public interface WithdrawnMemberRepository extends JpaRepository<WithdrawnMember
 	 */
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<WithdrawnMember> findWithLockByMemberId(Long memberId);
+
+	/**
+	 * TTL 이 지난 tombstone 일괄 삭제. 파생 쿼리(deleteBy...)는 행을 전부
+	 * 로딩한 뒤 한 건씩 지우므로 벌크 JPQL 로 한 문장에 지운다. 잠금 조회
+	 * 경로(upsert·탈퇴)와 경합하더라도 행 단위 X 락끼리의 대기일 뿐이고,
+	 * cutoff 이전 행만 건드리므로 최근 탈퇴 회원의 가드에는 영향이 없다.
+	 */
+	@Modifying(clearAutomatically = true)
+	@Query("delete from WithdrawnMember w where w.withdrawnAt < :cutoff")
+	int deleteAllByWithdrawnAtBefore(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/matching-service/src/main/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupScheduler.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupScheduler.java
@@ -1,0 +1,52 @@
+package com.comatching.matching.domain.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.comatching.matching.domain.repository.candidate.WithdrawnMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 탈퇴 tombstone TTL 정리 배치.
+ *
+ * tombstone 은 늦게 도착한 profile-updates 이벤트가 탈퇴 회원을 부활시키는
+ * 것을 막는 가드라서, 늦은 이벤트가 더 이상 올 수 없는 시점 이후에는 지워도
+ * 안전하다. 그 상한은 profile-updates 토픽의 retention(브로커 기본 7일) —
+ * 그보다 오래된 이벤트는 토픽에서 이미 소거되어 도착 자체가 불가능하다.
+ * 기본 보존 14일은 retention 의 2배로, 컨슈머 랙과 DLT 재처리 지연까지
+ * 감안한 여유다. profile-updates.DLT 재적재(re-drive)는 반드시 이 보존
+ * 기간 안에 해야 한다 — 그 뒤에 재적재하면 tombstone 이 이미 지워져
+ * 탈퇴 회원이 부활할 수 있다.
+ *
+ * 지우지 않고 영구히 쌓으면 저장 공간보다 재가입이 문제다: 같은 memberId 로
+ * 다시 가입한 회원의 프로필 이벤트가 tombstone 에 걸러져 영원히 매칭에서
+ * 제외된다. 이 배치가 그 차단을 TTL 로 한정한다.
+ *
+ * 다중 인스턴스에서 동시에 돌아도 벌크 삭제는 멱등이라 분산 락이 필요 없다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawnMemberCleanupScheduler {
+
+	private final WithdrawnMemberRepository withdrawnMemberRepository;
+
+	@Value("${matching.tombstone.retention-days:14}")
+	private long retentionDays;
+
+	@Scheduled(cron = "${matching.tombstone.cleanup-cron:0 0 4 * * *}")
+	@Transactional
+	public void purgeExpiredTombstones() {
+		LocalDateTime cutoff = LocalDateTime.now().minusDays(retentionDays);
+		int deleted = withdrawnMemberRepository.deleteAllByWithdrawnAtBefore(cutoff);
+		if (deleted > 0) {
+			log.info("[WithdrawnMemberCleanupScheduler] TTL 경과 tombstone {}건 삭제 (cutoff={})", deleted, cutoff);
+		}
+	}
+}

--- a/matching-service/src/main/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupScheduler.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupScheduler.java
@@ -17,12 +17,13 @@ import lombok.extern.slf4j.Slf4j;
  *
  * tombstone 은 늦게 도착한 profile-updates 이벤트가 탈퇴 회원을 부활시키는
  * 것을 막는 가드라서, 늦은 이벤트가 더 이상 올 수 없는 시점 이후에는 지워도
- * 안전하다. 그 상한은 profile-updates 토픽의 retention(브로커 기본 7일) —
- * 그보다 오래된 이벤트는 토픽에서 이미 소거되어 도착 자체가 불가능하다.
- * 기본 보존 14일은 retention 의 2배로, 컨슈머 랙과 DLT 재처리 지연까지
- * 감안한 여유다. profile-updates.DLT 재적재(re-drive)는 반드시 이 보존
- * 기간 안에 해야 한다 — 그 뒤에 재적재하면 tombstone 이 이미 지워져
- * 탈퇴 회원이 부활할 수 있다.
+ * 안전하다. 그 상한은 profile-updates 토픽의 retention(KafkaTopicConfig 에서
+ * 1일로 선언) — 그보다 오래된 이벤트는 토픽에서 이미 소거되어 도착 자체가
+ * 불가능하다. 기본 보존 2일은 retention 의 2배로, 컨슈머 랙과 DLT 재처리
+ * 지연까지 감안한 여유다. profile-updates.DLT 재적재(re-drive)는 반드시
+ * 이 보존 기간 안에 해야 한다 — 그 뒤에 재적재하면 tombstone 이 이미
+ * 지워져 탈퇴 회원이 부활할 수 있다. retention 을 늘리면 이 값도 같이
+ * 늘려야 한다.
  *
  * 지우지 않고 영구히 쌓으면 저장 공간보다 재가입이 문제다: 같은 memberId 로
  * 다시 가입한 회원의 프로필 이벤트가 tombstone 에 걸러져 영원히 매칭에서
@@ -37,7 +38,7 @@ public class WithdrawnMemberCleanupScheduler {
 
 	private final WithdrawnMemberRepository withdrawnMemberRepository;
 
-	@Value("${matching.tombstone.retention-days:14}")
+	@Value("${matching.tombstone.retention-days:2}")
 	private long retentionDays;
 
 	@Scheduled(cron = "${matching.tombstone.cleanup-cron:0 0 4 * * *}")

--- a/matching-service/src/main/java/com/comatching/matching/global/config/KafkaTopicConfig.java
+++ b/matching-service/src/main/java/com/comatching/matching/global/config/KafkaTopicConfig.java
@@ -1,10 +1,15 @@
 package com.comatching.matching.global.config;
 
+import java.time.Duration;
+
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.TopicConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
 
 /**
  * MatchingCandidate 를 조작하는 두 토픽의 스펙을 코드로 못박는다.
@@ -35,11 +40,38 @@ public class KafkaTopicConfig {
 
 	private static final short REPLICATION_FACTOR = 1;
 
+	/**
+	 * retention 1일. 축제 단발성 서비스라 브로커 기본 7일은 과하다.
+	 *
+	 * 단, "몇 분"까지는 못 줄인다. retention 은 저장 비용이 아니라 **컨슈머가
+	 * 죽어 있어도 되는 최대 시간**이다. 발행됐지만 아직 소비되지 않은 메시지는
+	 * retention 이 지나면 소비 여부와 무관하게 소거되므로, retention 이 컨슈머
+	 * 다운타임(배포, 야간 크래시)보다 짧으면 그 사이 발행분이 조용히 사라진다.
+	 * earliest 로 막은 신규 파티션 배정 지연(최대 5분)과 차단 재시도의
+	 * head-of-line 지연도 이 창 안에 들어와야 한다. 밤새 장애를 아침에 발견하는
+	 * 최악 시나리오를 덮는 하한이 1일이다.
+	 *
+	 * 탈퇴 tombstone TTL(matching.tombstone.retention-days)은 이 값의 2배와
+	 * 맞물려 있다 — retention 을 바꾸면 그쪽도 같이 바꿔야 한다.
+	 */
+	private static final long RETENTION_MS = Duration.ofDays(1).toMillis();
+
+	// KafkaAdmin 기본값은 기존 토픽의 config 를 건드리지 않는다(파티션 증설만).
+	// retention 선언이 이미 만들어진 토픽에도 적용되게 config 정렬을 켠다 —
+	// NewTopic 에 선언한 config 만 비교·수정하므로 다른 설정에는 영향이 없다.
+	@Bean
+	public KafkaAdmin kafkaAdmin(KafkaProperties properties) {
+		KafkaAdmin admin = new KafkaAdmin(properties.buildAdminProperties(null));
+		admin.setModifyTopicConfigs(true);
+		return admin;
+	}
+
 	@Bean
 	public NewTopic memberWithdrawTopic() {
 		return TopicBuilder.name("member-withdraw")
 			.partitions(CANDIDATE_TOPIC_PARTITIONS)
 			.replicas(REPLICATION_FACTOR)
+			.config(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(RETENTION_MS))
 			.build();
 	}
 
@@ -48,6 +80,7 @@ public class KafkaTopicConfig {
 		return TopicBuilder.name("profile-updates")
 			.partitions(CANDIDATE_TOPIC_PARTITIONS)
 			.replicas(REPLICATION_FACTOR)
+			.config(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(RETENTION_MS))
 			.build();
 	}
 }

--- a/matching-service/src/main/resources/application.yml
+++ b/matching-service/src/main/resources/application.yml
@@ -58,6 +58,13 @@ spring:
       s3:
         bucket: ${AWS_S3_BUCKET}
 
+matching:
+  tombstone:
+    # profile-updates retention(기본 7일)보다 길어야 한다. 근거는
+    # WithdrawnMemberCleanupScheduler 주석 참고.
+    retention-days: 14
+    cleanup-cron: "0 0 4 * * *"
+
 jwt:
   secret: ${JWT_SECRET}
   access-token:

--- a/matching-service/src/main/resources/application.yml
+++ b/matching-service/src/main/resources/application.yml
@@ -60,9 +60,9 @@ spring:
 
 matching:
   tombstone:
-    # profile-updates retention(기본 7일)보다 길어야 한다. 근거는
-    # WithdrawnMemberCleanupScheduler 주석 참고.
-    retention-days: 14
+    # profile-updates retention(KafkaTopicConfig, 1일)보다 길어야 한다.
+    # 근거는 WithdrawnMemberCleanupScheduler 주석 참고.
+    retention-days: 2
     cleanup-cron: "0 0 4 * * *"
 
 jwt:

--- a/matching-service/src/test/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupSchedulerIT.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupSchedulerIT.java
@@ -1,0 +1,81 @@
+package com.comatching.matching.domain.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.comatching.matching.domain.entity.WithdrawnMember;
+import com.comatching.matching.domain.repository.candidate.WithdrawnMemberRepository;
+import com.comatching.matching.support.MySqlContainerSupport;
+
+/**
+ * tombstone TTL 정리 검증.
+ *
+ * 잘못 지우면 두 방향으로 사고가 난다: TTL 이전 행을 지우면 늦은 갱신
+ * 이벤트가 탈퇴 회원을 부활시키고, TTL 경과 행을 남기면 같은 memberId 로
+ * 재가입한 회원이 영원히 매칭에서 제외된다. 두 방향을 모두 확인한다.
+ * 벌크 JPQL 삭제는 방언을 타므로 다른 IT 와 같은 실제 MySQL 로 검증한다.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(classes = WithdrawnMemberCleanupSchedulerIT.Config.class)
+@Import(WithdrawnMemberCleanupScheduler.class)
+@DisplayName("탈퇴 tombstone TTL 정리 배치")
+class WithdrawnMemberCleanupSchedulerIT extends MySqlContainerSupport {
+
+	private static final long RETENTION_DAYS = 14;
+
+	@Autowired
+	private WithdrawnMemberCleanupScheduler scheduler;
+
+	@Autowired
+	private WithdrawnMemberRepository withdrawnMemberRepository;
+
+	@Test
+	@DisplayName("TTL 이 지난 tombstone 만 지우고 보존 기간 내 tombstone 은 남긴다")
+	void purgeOnlyExpiredTombstones() {
+		LocalDateTime now = LocalDateTime.now();
+		withdrawnMemberRepository.saveAndFlush(
+			WithdrawnMember.of(1L, now.minusDays(RETENTION_DAYS + 1)));
+		withdrawnMemberRepository.saveAndFlush(
+			WithdrawnMember.of(2L, now.minusDays(RETENTION_DAYS - 1)));
+		withdrawnMemberRepository.saveAndFlush(
+			WithdrawnMember.of(3L, now.minusHours(1)));
+
+		scheduler.purgeExpiredTombstones();
+
+		assertThat(withdrawnMemberRepository.existsById(1L)).isFalse();
+		assertThat(withdrawnMemberRepository.existsById(2L)).isTrue();
+		assertThat(withdrawnMemberRepository.existsById(3L)).isTrue();
+	}
+
+	@Test
+	@DisplayName("지울 것이 없으면 아무 행도 건드리지 않는다")
+	void noopWhenNothingExpired() {
+		withdrawnMemberRepository.saveAndFlush(
+			WithdrawnMember.of(4L, LocalDateTime.now().minusDays(1)));
+
+		scheduler.purgeExpiredTombstones();
+
+		assertThat(withdrawnMemberRepository.existsById(4L)).isTrue();
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	@EntityScan(basePackageClasses = WithdrawnMember.class)
+	@EnableJpaRepositories(basePackageClasses = WithdrawnMemberRepository.class)
+	static class Config {
+	}
+}

--- a/matching-service/src/test/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupSchedulerIT.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/service/WithdrawnMemberCleanupSchedulerIT.java
@@ -35,7 +35,7 @@ import com.comatching.matching.support.MySqlContainerSupport;
 @DisplayName("탈퇴 tombstone TTL 정리 배치")
 class WithdrawnMemberCleanupSchedulerIT extends MySqlContainerSupport {
 
-	private static final long RETENTION_DAYS = 14;
+	private static final long RETENTION_DAYS = 2;
 
 	@Autowired
 	private WithdrawnMemberCleanupScheduler scheduler;


### PR DESCRIPTION
## 개요

#59 의 후속. 두 가지를 다룬다: (1) 탈퇴 tombstone 의 TTL 정리, (2) 후보 토픽 retention 축소.

탈퇴 tombstone(`withdrawn_member`)은 늦게 도착한 `profile-updates` 이벤트가 탈퇴 회원을 부활시키는 것을 막는 가드인데, **영구 보존하면 반대 방향의 사고**가 생긴다 — 같은 memberId 로 재가입한 회원의 프로필 이벤트가 tombstone 에 걸러져 영원히 매칭에서 제외된다. 늦은 이벤트가 올 수 있는 상한은 토픽 retention 이므로, 그 이후의 tombstone 은 지워도 안전하다.

## 변경 사항

1. **토픽 retention 1일 명시** (`KafkaTopicConfig`) — 축제 단발성 서비스라 브로커 기본 7일은 과함. 단 분 단위까지 줄이지 않은 이유: retention 은 저장 비용이 아니라 **컨슈머가 죽어 있어도 되는 최대 시간**이다. 배포·야간 크래시 다운타임보다 짧으면 그 사이 발행분이 재시도·DLT 개입 없이 조용히 사라진다. 야간 장애를 아침에 발견하는 시나리오를 덮는 하한 = 1일. 기존 토픽에도 적용되게 `KafkaAdmin.setModifyTopicConfigs(true)` 활성화. `.DLT` 토픽은 사람이 재처리하는 곳이라 기본 7일 유지
2. **`WithdrawnMemberCleanupScheduler`** — 매일 04시(`matching.tombstone.cleanup-cron`) `withdrawnAt` 이 보존 기간(기본 2일 = retention×2, `matching.tombstone.retention-days`)을 넘긴 행을 벌크 삭제. 멱등이라 다중 인스턴스 동시 실행에도 분산 락 불요
3. **벌크 JPQL 삭제** — 파생 `deleteBy` 는 행을 전부 로딩 후 한 건씩 지우므로 한 문장 벌크로. cutoff 이전 행만 건드려 최근 탈퇴 가드와 경합하지 않음
4. **`@EnableScheduling`** — matching-service 에 스케줄링 활성화 (item-service 와 동일 패턴)

## 운영 제약 (문서에 명시)

- `profile-updates.DLT` 재적재(re-drive)는 **2일 안에** 해야 한다. TTL 이후 재적재하면 tombstone 이 지워져 탈퇴 회원이 부활할 수 있다
- retention 을 바꾸면 `retention-days` 도 같이(2배 관계) 바꿔야 한다

## 검증

- 실제 MySQL(Testcontainers)로 TTL 경계 양쪽 + no-op 케이스 확인 (`WithdrawnMemberCleanupSchedulerIT`)
- matching-service 전체 테스트 회귀 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)