### PR TITLE
refactor(kafka): 리스너 병렬도를 코드 상수에서 설정값으로 분리

### DIFF
--- a/KAFKA_PARTITIONING.md
+++ b/KAFKA_PARTITIONING.md
@@ -124,11 +124,17 @@ flowchart LR
   관리를 끈다(KafkaAdmin 이 기동 시 접속을 시도하며 타임아웃까지 기다리는
   것을 막는다).
 
-### 3. 컨슈머 병렬성 활용 — `concurrency = 3`
+### 3. 컨슈머 병렬성 — 설정값 (`matching.kafka.candidate-listener-concurrency`)
 
-두 `@KafkaListener` 의 concurrency 를 파티션 수와 같은 상수
-(`KafkaTopicConfig.CANDIDATE_LISTENER_CONCURRENCY`)로 묶었다. 파티션 수보다
-큰 값은 유휴 스레드만 만들기 때문에 두 숫자는 한 곳에서 관리한다.
+두 `@KafkaListener` 의 concurrency 는 설정값이다(기본 3). 처음에는 파티션
+수와 같은 상수로 묶었지만, 두 숫자의 성격이 달라서 풀었다. 파티션 수는
+늘릴 수만 있는 비가역 결정이라 코드에 박는 게 맞고, concurrency 는 재기동으로
+바꿀 수 있는 데다 적정값이 실제 트래픽·인스턴스 수를 본 뒤에야 정해지므로
+그 판단을 코드 상수로 미리 닫아 둘 이유가 없다.
+
+조정 범위: 파티션 수(3)를 넘는 값은 유휴 스레드만 만들므로 상한은 3.
+줄이는 것은 자유다 — 회원 단위 순서는 "같은 키 = 같은 파티션"이라는
+프로듀서 쪽 속성으로 보장되므로 소비 스레드 수를 줄여도 깨지지 않는다.
 
 ### 4. 탈퇴 tombstone — 키로는 못 막는 역전을 닫는다
 

--- a/matching-service/src/main/java/com/comatching/matching/global/config/KafkaTopicConfig.java
+++ b/matching-service/src/main/java/com/comatching/matching/global/config/KafkaTopicConfig.java
@@ -34,9 +34,14 @@ public class KafkaTopicConfig {
 
 	public static final int CANDIDATE_TOPIC_PARTITIONS = 3;
 
-	// @KafkaListener 의 concurrency 는 String 만 받는다. 파티션 수보다 큰 값은
-	// 유휴 스레드만 만들므로 두 상수는 반드시 같은 값을 가리켜야 한다.
-	public static final String CANDIDATE_LISTENER_CONCURRENCY = "" + CANDIDATE_TOPIC_PARTITIONS;
+	// 리스너 병렬도는 파티션 수와 달리 운영 중에 조정할 여지를 남긴다. 파티션은
+	// 늘릴 수만 있는 비가역 결정이지만 concurrency 는 재기동만으로 바꿀 수 있고,
+	// 적정값은 실제 트래픽과 인스턴스 수를 본 뒤에야 정할 수 있기 때문이다.
+	// 조정 범위: 파티션 수(3)를 넘는 값은 유휴 스레드만 만들므로 상한은 3,
+	// 줄이는 것은 자유다 — 회원 단위 순서는 "같은 키 = 같은 파티션"(프로듀서
+	// 속성)으로 보장되므로 스레드 수를 줄여도 깨지지 않는다.
+	public static final String CANDIDATE_LISTENER_CONCURRENCY =
+		"${matching.kafka.candidate-listener-concurrency:3}";
 
 	private static final short REPLICATION_FACTOR = 1;
 

--- a/matching-service/src/main/java/com/comatching/matching/infra/kafka/MatchingMemberEventConsumer.java
+++ b/matching-service/src/main/java/com/comatching/matching/infra/kafka/MatchingMemberEventConsumer.java
@@ -15,8 +15,8 @@ public class MatchingMemberEventConsumer {
 
 	private final CandidateService candidateService;
 
-	// concurrency 는 파티션 수(KafkaTopicConfig)와 묶여 있다. 프로듀서가 memberId 를
-	// 키로 걸어 주므로 같은 회원의 이벤트는 항상 같은 파티션 = 같은 스레드로 온다.
+	// concurrency 는 설정값(상한은 파티션 수, KafkaTopicConfig 참고). 프로듀서가
+	// memberId 를 키로 걸어 주므로 같은 회원의 이벤트는 항상 같은 파티션으로 온다.
 	@KafkaListener(topics = "member-withdraw", groupId = "matching-service-group",
 		concurrency = KafkaTopicConfig.CANDIDATE_LISTENER_CONCURRENCY)
 	public void handleMemberWithdraw(MemberWithdrawnEvent event) {

--- a/matching-service/src/main/resources/application.yml
+++ b/matching-service/src/main/resources/application.yml
@@ -59,6 +59,10 @@ spring:
         bucket: ${AWS_S3_BUCKET}
 
 matching:
+  kafka:
+    # member-withdraw · profile-updates 리스너 병렬도. 상한은 파티션 수(3) —
+    # 넘는 값은 유휴 스레드만 만든다. 트래픽·인스턴스 수를 보고 조정한다.
+    candidate-listener-concurrency: 3
   tombstone:
     # profile-updates retention(KafkaTopicConfig, 1일)보다 길어야 한다.
     # 근거는 WithdrawnMemberCleanupScheduler 주석 참고.


### PR DESCRIPTION
## 개요

concurrency 3 고정은 "파티션 수와 항상 같아야 한다"는 판단을 코드에 박아 운영 시점의 조정 여지를 닫는다. 파티션 수는 늘릴 수만 있는 비가역 결정이라 코드 상수가 맞지만, concurrency 는 재기동만으로 바꿀 수 있고 적정값은 실제 트래픽·인스턴스 수를 본 뒤에야 정해진다.

## 변경 사항

- `CANDIDATE_LISTENER_CONCURRENCY` 를 `${matching.kafka.candidate-listener-concurrency:3}` 플레이스홀더로 변경 — 정의 지점은 한 곳 유지, 값만 yml 로
- 기본값 3 유지로 동작 변화 없음. 조정 범위(상한 = 파티션 수 3, 축소는 순서 보장에 무관)를 주석·문서에 명시

## 검증

- matching-service 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)