### PR TITLE
feat(kafka): DLT 적재 웹훅 알림

### DIFF
--- a/KAFKA_PARTITIONING.md
+++ b/KAFKA_PARTITIONING.md
@@ -329,6 +329,29 @@ tombstone 은 늦은 갱신 이벤트가 올 수 있는 동안만 필요하다. 
 DLT 토픽 스펙도 코드에 박았다(`comatching.kafka.dlt-topics`). 운영 환경은
 auto-create가 꺼져 있어 DLT 토픽이 없으면 옮길 곳 자체가 없기 때문이다.
 
+### DLT 적재 알림 — 쌓인 걸 이틀 안에 알아채야 한다
+
+DLT 는 사람이 열어 보고 고치는 저장소인데, 적재 사실을 사람이 모르면
+유실을 눈에 보이게 만든 의미가 없다. 특히 `profile-updates.DLT` 재적재는
+tombstone TTL(2일) 안에 해야 하므로 알아채는 데에 기한이 있다.
+
+`DeadLetterPublishingRecoverer` 를 감싸 **DLT 발행이 성공한 직후** 웹훅으로
+알린다(`KafkaDltAlertNotifier`, `comatching.kafka.dlt-alert-webhook-url`).
+본문에 `{"content", "text"}` 두 키를 같이 실어 Discord·Slack 어느 웹훅
+URL 을 줘도 동작한다. 설계 결정들:
+
+- **Prometheus + Alertmanager 가 아닌 이유** — 현재 모니터링 스택은 부하
+  테스트 때만 띄우는 구성이라 상시 알림의 기반이 못 되고, 알림 하나를 위해
+  Alertmanager·kafka-exporter 를 상시 운영에 추가하는 것은 단발성 서비스에
+  과하다. 발행 시점 알림은 어느 메시지가 왜 실패했는지까지 본문에 실린다.
+- **토픽별 쿨다운(기본 5분)** — poison pill 뒤 백로그가 연쇄로 DLT 에
+  떨어지면 웹훅이 도배되고, rate limit 에 걸리면 정작 다른 토픽의 알림까지
+  막힌다. 억제된 건수는 다음 알림에 합산 보고한다.
+- **전송 실패는 삼킨다** — 알림 장애가 소비 흐름(오프셋 진행)을 막으면
+  주객전도다. 웹훅과 무관하게 적재는 항상 `log.error` 로 남는다.
+- **발행 성공 후에만 알린다** — DLT 발행 자체가 실패하면 recoverer 예외가
+  에러 핸들러로 전파되어 다시 다뤄지므로, 그 시점 알림은 이르다.
+
 ## 검증
 
 | 테스트 | 방식 | 결과 |
@@ -342,6 +365,8 @@ auto-create가 꺼져 있어 DLT 토픽이 없으면 옮길 곳 자체가 없기
 | TTL 경과 tombstone 만 삭제되고 보존 기간 내 행은 남는다 | 실제 MySQL (`WithdrawnMemberCleanupSchedulerIT`) | ✅ |
 | 계속 실패하는 메시지가 재시도 4회(최초 1 + 3) 후 `.DLT` 로 옮겨지고, 원본 키·위치 헤더가 보존됨 | EmbeddedKafka, 실제 실패 리스너 (`KafkaRetryAndDltIT`) | ✅ |
 | 일시적 실패는 재시도로 회복되고 DLT 로 가지 않음 | 〃 | ✅ |
+| DLT 이동 시에만 알림 발화, 회복된 실패는 알리지 않음 | 〃 | ✅ |
+| 쿨다운 억제·억제 건수 합산 보고·토픽별 독립·미설정 시 no-op | 시계 주입 단위 테스트 (`KafkaDltAlertNotifierTest`) | ✅ |
 
 user-service · matching-service 전체 테스트 회귀 통과 (failures 0, errors 0).
 구현 후 별도의 다각도 검증(Kafka 의미론·JPA 잠금·운영 설정)을 거쳐 발견된
@@ -349,9 +374,9 @@ user-service · matching-service 전체 테스트 회귀 통과 (failures 0, err
 
 ## 남은 한계 (다음 순서)
 
-1. **DLT 에 쌓인 메시지를 되돌리는 경로가 없다** — 유실이 눈에 보이게 됐을
-   뿐, 원인을 고친 뒤 재처리하는 것은 아직 수동이다. 적재를 알리는 알람과
-   재처리 수단이 다음 단계다.
+1. **DLT 에 쌓인 메시지를 되돌리는 경로가 없다** — 적재 알람은 붙였지만,
+   원인을 고친 뒤 재처리하는 것은 아직 수동(콘솔 재발행)이다. 재적재 기한이
+   tombstone TTL(2일)로 묶여 있으므로 재처리 수단이 다음 단계다.
 2. **메일 발송은 재시도가 중복 발송이 될 수 있다** — 후보 삭제·갱신은 멱등이라
    재시도가 안전하지만, notification 의 메일은 SMTP 타임아웃처럼 "보냈는지
    모르는" 실패에서 같은 메일이 두 번 갈 수 있다. 누락보다 중복이 낫다고

--- a/chat-service/src/main/resources/application-aws.yml
+++ b/chat-service/src/main/resources/application-aws.yml
@@ -66,3 +66,5 @@ management:
 comatching:
   kafka:
     dlt-topics: matching-success-topic
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}

--- a/chat-service/src/main/resources/application.yml
+++ b/chat-service/src/main/resources/application.yml
@@ -74,3 +74,5 @@ management:
 comatching:
   kafka:
     dlt-topics: matching-success-topic
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}

--- a/common-module/src/main/java/com/comatching/common/config/kafka/KafkaConsumerConfig.java
+++ b/common-module/src/main/java/com/comatching/common/config/kafka/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package com.comatching.common.config.kafka;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,6 +19,7 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.MicrometerConsumerListener;
+import org.springframework.kafka.listener.ConsumerAwareRecordRecoverer;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
@@ -86,11 +88,20 @@ public class KafkaConsumerConfig {
 	 * Feign 호출 실패 같은 일시적 원인이 업무 예외로 감싸여 올라오는 경로가 있어서,
 	 * 재시도 제외로 분류하면 회복할 수 있는 실패까지 DLT 로 보내게 된다.
 	 */
+	// DLT 적재를 사람에게 알린다. 웹훅 URL 이 비어 있으면 로그만 남기는 no-op.
+	@Bean
+	public KafkaDltAlertNotifier kafkaDltAlertNotifier(
+		@Value("${comatching.kafka.dlt-alert-webhook-url:}") String webhookUrl,
+		@Value("${comatching.kafka.dlt-alert-cooldown-seconds:300}") long cooldownSeconds) {
+		return new KafkaDltAlertNotifier(webhookUrl, groupId, Duration.ofSeconds(cooldownSeconds));
+	}
+
 	@Bean
 	public DefaultErrorHandler kafkaErrorHandler(
 		@Qualifier("kafkaTemplate") KafkaOperations<String, String> stringTemplate,
 		@Qualifier("jsonKafkaTemplate") KafkaOperations<String, Object> jsonTemplate,
-		@Qualifier("bytesKafkaTemplate") KafkaOperations<String, byte[]> bytesTemplate) {
+		@Qualifier("bytesKafkaTemplate") KafkaOperations<String, byte[]> bytesTemplate,
+		KafkaDltAlertNotifier dltAlertNotifier) {
 
 		// 값 타입에 따라 템플릿을 고른다. 가장 구체적인 타입이 앞에 와야 하므로
 		// 순서가 보존되는 맵을 쓰고 Object 를 마지막에 둔다.
@@ -111,7 +122,14 @@ public class KafkaConsumerConfig {
 		backOff.setMultiplier(RETRY_MULTIPLIER);
 		backOff.setMaxInterval(RETRY_MAX_INTERVAL_MS);
 
-		return new DefaultErrorHandler(recoverer, backOff);
+		// DLT 발행이 성공한 뒤에만 알린다. 발행 자체가 실패하면 recoverer 예외가
+		// 위로 전파되어 에러 핸들러가 다시 다루므로, 그때 알리는 건 이르다.
+		ConsumerAwareRecordRecoverer alertingRecoverer = (record, consumer, exception) -> {
+			recoverer.accept(record, consumer, exception);
+			dltAlertNotifier.notifyParked(record, exception);
+		};
+
+		return new DefaultErrorHandler(alertingRecoverer, backOff);
 	}
 
 	@Bean

--- a/common-module/src/main/java/com/comatching/common/config/kafka/KafkaDltAlertNotifier.java
+++ b/common-module/src/main/java/com/comatching/common/config/kafka/KafkaDltAlertNotifier.java
@@ -1,0 +1,143 @@
+package com.comatching.common.config.kafka;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * DLT 적재 알림.
+ *
+ * DLT 는 "사람이 열어 보고 고치는" 저장소인데, 적재 사실을 사람이 모르면
+ * 유실을 눈에 보이게 만든 의미가 없다. 특히 profile-updates.DLT 재적재는
+ * tombstone TTL(2일) 안에 해야 하므로, 쌓인 걸 이틀 안에 알아채는 것이
+ * 재처리 수단보다 먼저다.
+ *
+ * Prometheus + Alertmanager 경로가 아니라 발행 시점 직접 웹훅인 이유:
+ * 현재 모니터링 스택(docker-compose.monitoring.yml)은 부하 테스트용으로
+ * 필요할 때만 띄우는 구성이라 상시 알림의 기반이 못 되고, Alertmanager ·
+ * kafka-exporter 를 상시 운영에 추가하는 것은 축제 단발성 서비스에 과하다.
+ * 발행 시점 알림은 어느 메시지가 왜 실패했는지까지 본문에 실을 수 있다는
+ * 덤도 있다.
+ *
+ * 웹훅 본문은 {"content", "text"} 두 키를 함께 보낸다. Discord 는 content 를,
+ * Slack 은 text 를 읽고 서로 모르는 키는 무시하므로 URL 만 바꾸면 둘 다 된다.
+ *
+ * 같은 토픽의 연속 실패(예: poison pill 뒤 백로그)가 웹훅을 도배하지 않도록
+ * 토픽별 쿨다운을 두고, 억제된 건수는 다음 알림에 합산해 보고한다.
+ * 전송 실패는 삼킨다 - 알림 장애가 소비 흐름(오프셋 진행)을 막으면 안 된다.
+ */
+@Slf4j
+public class KafkaDltAlertNotifier {
+
+	private static final int HTTP_TIMEOUT_MS = 3_000;
+	private static final int EXCEPTION_MESSAGE_MAX_LENGTH = 300;
+
+	private final boolean enabled;
+	private final String groupId;
+	private final long cooldownMs;
+	private final RestClient restClient;
+	private final ConcurrentHashMap<String, Window> windows = new ConcurrentHashMap<>();
+
+	private static final class Window {
+		volatile long lastSentAt = -1;
+		final AtomicLong suppressed = new AtomicLong();
+	}
+
+	public KafkaDltAlertNotifier(String webhookUrl, String groupId, Duration cooldown) {
+		this.enabled = webhookUrl != null && !webhookUrl.isBlank();
+		this.groupId = groupId;
+		this.cooldownMs = cooldown.toMillis();
+
+		if (enabled) {
+			SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+			requestFactory.setConnectTimeout(HTTP_TIMEOUT_MS);
+			requestFactory.setReadTimeout(HTTP_TIMEOUT_MS);
+			this.restClient = RestClient.builder()
+				.baseUrl(webhookUrl)
+				.requestFactory(requestFactory)
+				.build();
+		} else {
+			this.restClient = null;
+			log.info("DLT 알림 웹훅 미설정(comatching.kafka.dlt-alert-webhook-url) - 적재 시 로그만 남는다");
+		}
+	}
+
+	/**
+	 * DLT 발행이 성공한 직후 호출된다. 발행 실패는 recoverer 예외로 전파되어
+	 * 에러 핸들러가 다시 다루므로 여기까지 오지 않는다.
+	 */
+	public void notifyParked(ConsumerRecord<?, ?> record, Exception exception) {
+		// 웹훅과 무관하게 항상 남긴다. 웹훅이 없거나 죽었을 때의 최후 흔적이다.
+		log.error("DLT 적재: {}{} (원본 p{}@{}, key={}, group={})",
+			record.topic(), KafkaConsumerConfig.DLT_SUFFIX,
+			record.partition(), record.offset(), record.key(), groupId, exception);
+
+		if (!enabled) {
+			return;
+		}
+
+		Window window = windows.computeIfAbsent(record.topic(), topic -> new Window());
+		long suppressedSoFar;
+		long now = nowMillis();
+		synchronized (window) {
+			if (window.lastSentAt >= 0 && now - window.lastSentAt < cooldownMs) {
+				window.suppressed.incrementAndGet();
+				return;
+			}
+			suppressedSoFar = window.suppressed.getAndSet(0);
+			window.lastSentAt = now;
+		}
+
+		deliver(buildMessage(record, exception, suppressedSoFar));
+	}
+
+	private String buildMessage(ConsumerRecord<?, ?> record, Exception exception, long suppressed) {
+		String cause = rootCauseSummary(exception);
+		StringBuilder message = new StringBuilder()
+			.append("🚨 [").append(groupId).append("] DLT 적재: ")
+			.append(record.topic()).append(KafkaConsumerConfig.DLT_SUFFIX).append('\n')
+			.append("원본 ").append(record.topic())
+			.append(" p").append(record.partition()).append('@').append(record.offset())
+			.append(" · key=").append(record.key()).append('\n')
+			.append("예외 ").append(cause);
+		if (suppressed > 0) {
+			message.append("\n(직전 쿨다운 동안 같은 토픽 ").append(suppressed).append("건 추가 적재)");
+		}
+		return message.toString();
+	}
+
+	private String rootCauseSummary(Exception exception) {
+		Throwable cause = exception;
+		while (cause.getCause() != null) {
+			cause = cause.getCause();
+		}
+		String text = cause.getClass().getSimpleName() + ": " + cause.getMessage();
+		return text.length() > EXCEPTION_MESSAGE_MAX_LENGTH
+			? text.substring(0, EXCEPTION_MESSAGE_MAX_LENGTH) + "…"
+			: text;
+	}
+
+	protected void deliver(String message) {
+		try {
+			restClient.post()
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(Map.of("content", message, "text", message))
+				.retrieve()
+				.toBodilessEntity();
+		} catch (Exception e) {
+			log.warn("DLT 알림 웹훅 전송 실패 - 소비 흐름에는 영향 없음", e);
+		}
+	}
+
+	protected long nowMillis() {
+		return System.currentTimeMillis();
+	}
+}

--- a/common-module/src/test/java/com/comatching/common/config/kafka/KafkaDltAlertNotifierTest.java
+++ b/common-module/src/test/java/com/comatching/common/config/kafka/KafkaDltAlertNotifierTest.java
@@ -1,0 +1,97 @@
+package com.comatching.common.config.kafka;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 쿨다운 억제 로직 검증.
+ *
+ * 알림이 안 가는 것과 도배되는 것 모두 사고다: 안 가면 tombstone TTL(2일)
+ * 안에 재처리할 기회를 놓치고, 도배되면(poison pill 뒤 백로그) 웹훅 rate
+ * limit 에 걸려 정작 다른 토픽의 알림까지 막힌다. 시계를 주입해 경계를
+ * 결정적으로 확인한다.
+ */
+@DisplayName("DLT 적재 알림 쿨다운")
+class KafkaDltAlertNotifierTest {
+
+	private static final Duration COOLDOWN = Duration.ofMinutes(5);
+
+	static class TestNotifier extends KafkaDltAlertNotifier {
+		long now = 1L;
+		final List<String> sent = new ArrayList<>();
+
+		TestNotifier(String webhookUrl) {
+			super(webhookUrl, "test-group", COOLDOWN);
+		}
+
+		@Override
+		protected long nowMillis() {
+			return now;
+		}
+
+		@Override
+		protected void deliver(String message) {
+			sent.add(message);
+		}
+	}
+
+	private ConsumerRecord<Object, Object> record(String topic) {
+		return new ConsumerRecord<>(topic, 0, 0L, "42", "payload");
+	}
+
+	@Test
+	@DisplayName("첫 적재는 즉시 알리고, 쿨다운 내 같은 토픽 적재는 억제된다")
+	void suppressesWithinCooldown() {
+		TestNotifier notifier = new TestNotifier("http://webhook");
+
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+
+		assertThat(notifier.sent).hasSize(1);
+		assertThat(notifier.sent.get(0)).contains("topic-a.DLT").contains("key=42");
+	}
+
+	@Test
+	@DisplayName("쿨다운이 지나면 다시 알리고, 억제됐던 건수를 함께 보고한다")
+	void reportsSuppressedCountAfterCooldown() {
+		TestNotifier notifier = new TestNotifier("http://webhook");
+
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+
+		notifier.now += COOLDOWN.toMillis();
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+
+		assertThat(notifier.sent).hasSize(2);
+		assertThat(notifier.sent.get(1)).contains("2건 추가 적재");
+	}
+
+	@Test
+	@DisplayName("쿨다운은 토픽별로 독립이다 - 한 토픽의 폭주가 다른 토픽 알림을 막지 않는다")
+	void cooldownIsPerTopic() {
+		TestNotifier notifier = new TestNotifier("http://webhook");
+
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+		notifier.notifyParked(record("topic-b"), new IllegalStateException("boom"));
+
+		assertThat(notifier.sent).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("웹훅 URL 이 비어 있으면 전송하지 않는다")
+	void disabledWhenUrlBlank() {
+		TestNotifier notifier = new TestNotifier("");
+
+		notifier.notifyParked(record("topic-a"), new IllegalStateException("boom"));
+
+		assertThat(notifier.sent).isEmpty();
+	}
+}

--- a/common-module/src/test/java/com/comatching/common/config/kafka/KafkaRetryAndDltIT.java
+++ b/common-module/src/test/java/com/comatching/common/config/kafka/KafkaRetryAndDltIT.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -41,6 +43,7 @@ import org.springframework.test.context.TestPropertySource;
  *  1) 계속 실패하면 정해진 횟수만큼 재시도한 뒤 <토픽>.DLT 로 옮겨진다 (조용한 유실 아님)
  *  2) 일시적 실패는 재시도로 회복되고 DLT 로 가지 않는다
  *  3) 원본 키와 위치 헤더가 DLT 에 보존된다 (어느 회원 건인지 추적 가능)
+ *  4) DLT 이동 시에만 알림이 발화한다 (회복된 실패는 알리지 않는다)
  */
 @SpringBootTest(classes = {
 	KafkaProducerConfig.class,
@@ -104,6 +107,11 @@ class KafkaRetryAndDltIT {
 
 		// 최초 1회 + 재시도 3회. 즉시 포기하지도, 무한히 매달리지도 않는다.
 		assertThat(listeners.alwaysFailsAttempts.get()).isEqualTo(4);
+
+		// DLT 이동은 사람에게 알려진다. 적재를 이틀(tombstone TTL) 안에
+		// 알아채야 재처리가 의미 있기 때문이다.
+		assertThat(listeners.alerts)
+			.anySatisfy(alert -> assertThat(alert).contains(ALWAYS_FAILS_TOPIC + ".DLT"));
 	}
 
 	@Test
@@ -115,8 +123,11 @@ class KafkaRetryAndDltIT {
 			.atMost(30, TimeUnit.SECONDS)
 			.untilAsserted(() -> assertThat(listeners.recovered).contains(PAYLOAD_AT_LISTENER));
 
-		// 2번째 시도에서 성공했으므로 DLT 는 비어 있어야 한다
+		// 2번째 시도에서 성공했으므로 DLT 는 비어 있어야 하고, 알림도 없어야 한다.
+		// 회복된 실패까지 알리면 알림이 늑대소년이 된다.
 		assertThat(pollOne(RECOVERS_TOPIC + ".DLT", Duration.ofSeconds(5))).isNull();
+		assertThat(listeners.alerts)
+			.noneSatisfy(alert -> assertThat(alert).contains(RECOVERS_TOPIC));
 	}
 
 	private ConsumerRecord<String, String> pollOne(String topic, Duration timeout) {
@@ -147,6 +158,20 @@ class KafkaRetryAndDltIT {
 		final AtomicInteger alwaysFailsAttempts = new AtomicInteger();
 		final AtomicInteger recoversAttempts = new AtomicInteger();
 		final List<String> recovered = new CopyOnWriteArrayList<>();
+		final List<String> alerts = new CopyOnWriteArrayList<>();
+
+		// 실제 웹훅 대신 전송 내용을 기록한다. HTTP 를 목으로 갈아끼우는 게 아니라
+		// 전송 직전 지점(deliver)만 가로채므로 쿨다운·메시지 조립은 실물이 돈다.
+		@Bean
+		@Primary
+		KafkaDltAlertNotifier recordingDltAlertNotifier() {
+			return new KafkaDltAlertNotifier("http://recording-stub", "kafka-retry-dlt-it", Duration.ZERO) {
+				@Override
+				protected void deliver(String message) {
+					alerts.add(message);
+				}
+			};
+		}
 
 		@KafkaListener(topics = ALWAYS_FAILS_TOPIC, groupId = "always-fails-group")
 		void alwaysFails(String payload) {

--- a/item-service/src/main/resources/application-aws.yml
+++ b/item-service/src/main/resources/application-aws.yml
@@ -75,15 +75,15 @@ comatching:
       enabled: ${PRE_SIGNUP_MATCHING_TICKET_GRANT_ENABLED:true}
       quantity: ${PRE_SIGNUP_MATCHING_TICKET_GRANT_QUANTITY:1}
       campaign-code: ${PRE_SIGNUP_MATCHING_TICKET_GRANT_CAMPAIGN_CODE:PRE_SIGNUP_2026}
+  kafka:
+    # 재시도를 다 쓴 메시지를 옮길 DLT 토픽(<토픽>.DLT)을 기동 시 만든다.
+    # 이 서비스가 소비하는 토픽만 적는다.
+    dlt-topics: member-signup
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}
 
 management:
   endpoints:
     web:
       exposure:
         include: health
-
-# 재시도를 다 쓴 메시지를 옮길 DLT 토픽(<토픽>.DLT)을 기동 시 만든다.
-# 이 서비스가 소비하는 토픽만 적는다.
-comatching:
-  kafka:
-    dlt-topics: member-signup

--- a/item-service/src/main/resources/application.yml
+++ b/item-service/src/main/resources/application.yml
@@ -67,6 +67,12 @@ comatching:
       enabled: ${PRE_SIGNUP_MATCHING_TICKET_GRANT_ENABLED:true}
       quantity: ${PRE_SIGNUP_MATCHING_TICKET_GRANT_QUANTITY:1}
       campaign-code: ${PRE_SIGNUP_MATCHING_TICKET_GRANT_CAMPAIGN_CODE:PRE_SIGNUP_2026}
+  kafka:
+    # 재시도를 다 쓴 메시지를 옮길 DLT 토픽(<토픽>.DLT)을 기동 시 만든다.
+    # 이 서비스가 소비하는 토픽만 적는다.
+    dlt-topics: member-signup
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}
 
 management:
   endpoints:
@@ -87,9 +93,3 @@ management:
         spring.kafka.listener: true
       slo:
         http.server.requests: 50ms,100ms,200ms,500ms,1s,2s
-
-# 재시도를 다 쓴 메시지를 옮길 DLT 토픽(<토픽>.DLT)을 기동 시 만든다.
-# 이 서비스가 소비하는 토픽만 적는다.
-comatching:
-  kafka:
-    dlt-topics: member-signup

--- a/matching-service/src/main/resources/application-aws.yml
+++ b/matching-service/src/main/resources/application-aws.yml
@@ -82,3 +82,5 @@ management:
 comatching:
   kafka:
     dlt-topics: member-withdraw,profile-updates
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}

--- a/matching-service/src/main/resources/application.yml
+++ b/matching-service/src/main/resources/application.yml
@@ -104,3 +104,5 @@ management:
 comatching:
   kafka:
     dlt-topics: member-withdraw,profile-updates
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}

--- a/notification/src/main/resources/application-aws.yml
+++ b/notification/src/main/resources/application-aws.yml
@@ -43,3 +43,5 @@ management:
 comatching:
   kafka:
     dlt-topics: member-signup,member-withdraw,chat-notification
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -53,3 +53,5 @@ management:
 comatching:
   kafka:
     dlt-topics: member-signup,member-withdraw,chat-notification
+    # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
+    dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}


### PR DESCRIPTION
## 개요

DLT 는 사람이 열어 보고 고치는 저장소인데 적재 사실을 사람이 모르면 유실을 눈에 보이게 만든 의미가 없다. 특히 `profile-updates.DLT` 재적재는 tombstone TTL(**2일**) 안에 해야 하므로, 쌓인 걸 이틀 안에 알아채는 것이 재처리 수단보다 먼저다. "남은 한계" 1번의 알람 절반을 채운다.

## 변경 사항

1. **`KafkaDltAlertNotifier`** — `DeadLetterPublishingRecoverer` 를 감싸 **DLT 발행 성공 직후** 웹훅 알림. 본문에 `content`·`text` 두 키를 같이 실어 **Discord·Slack 어느 웹훅 URL 이든 동작**(`comatching.kafka.dlt-alert-webhook-url`, 비우면 로그만)
2. **토픽별 쿨다운(기본 5분)** — poison pill 백로그의 웹훅 도배 방지, 억제 건수는 다음 알림에 합산 보고
3. **전송 실패는 삼킨다** — 알림 장애가 소비 흐름(오프셋 진행)을 막으면 주객전도. 적재는 웹훅과 무관하게 항상 `log.error`
4. **Prometheus+Alertmanager 미채택** — 현 모니터링 스택은 부하 테스트용 온디맨드 구성이라 상시 알림 기반이 못 되고, 알림 하나에 exporter·Alertmanager 상시 운영은 단발성 서비스에 과함
5. **(버그 수정)** item-service yml 의 최상위 `comatching:` 키 중복 병합 — #61 이 기존 블록을 못 보고 끝에 새 블록을 추가해 SnakeYAML `DuplicateKeyException` 으로 item-service 컨텍스트 로드가 전부 깨지는 상태였다(당시 common-module 테스트만 돌려 미발견)

## 사용법

각 서비스 환경변수 `DLT_ALERT_WEBHOOK_URL` 에 Discord 또는 Slack 웹훅 URL 지정.

## 검증

- IT(실제 브로커): DLT 이동 시에만 알림 발화, 회복된 실패는 미발화
- 단위(시계 주입): 쿨다운 경계·억제 합산·토픽별 독립·미설정 no-op
- 전 모듈 테스트 통과 (item-service 포함 — 수정 전에는 yml 중복으로 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)