### PR TITLE
배포 파이프라인 구성과 운영 프로파일 정리

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# 빌드 컨텍스트에서 뺀다. 특히 .env 계열은 이미지에 절대 들어가면 안 된다.
+.env
+.env.*
+!.env.prod.example
+
+.git
+.gitignore
+.gradle
+build
+**/build
+.idea
+.vscode
+.claude
+.gemini
+
+logs
+.pids
+cookies.txt
+_workspace
+
+# 로컬 전용 자산
+docker-compose.local.yml
+docker-compose.monitoring.yml
+monitoring
+database
+tools
+docs
+run-local.sh
+stop-local.sh
+*.md

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,87 @@
+# ============================================================
+# 운영 환경변수 템플릿. 이 파일을 .env.prod 로 복사해서 값을 채운다.
+#   cp .env.prod.example .env.prod
+# .env.prod 는 .gitignore 에 있으므로 실제 값은 커밋되지 않는다.
+#
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build
+# ============================================================
+
+# ---------- 배포 이미지 ----------
+# CI(.github/workflows/deploy.yml)가 배포할 때마다 IMAGE_TAG 를 그 커밋의 SHA 로
+# 덮어쓴다. 지금 EC2 에 어떤 버전이 떠 있는지가 이 한 줄에 남는다.
+#
+# 되돌리기: 예전 SHA 로 바꾸고 아래를 실행한다.
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod pull
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --no-build
+#
+# CI 없이 EC2 에서 직접 빌드할 거면 이 줄은 없어도 된다(기본값 latest).
+IMAGE_TAG=latest
+
+# ---------- 스키마 관리 ----------
+# 첫 배포에서만 create 로 스키마를 만든다. 만들어진 뒤에는 이 줄을 지워서
+# 기본값 validate 로 돌린다 - validate 는 엔티티와 실제 스키마가 어긋나면
+# 기동을 거부할 뿐 스키마를 건드리지 않는다.
+# create 인 채로 재기동하면 데이터가 전부 날아간다.
+JPA_DDL_AUTO=create
+
+# ---------- RDS (MySQL) ----------
+RDS_ENDPOINT=
+RDS_USERNAME=
+RDS_PASSWORD=
+
+# ---------- Redis (EC2 컨테이너) ----------
+# 컴포즈의 서비스명이 곧 호스트명이다. ElastiCache 로 되돌리려면
+# REDIS_ENDPOINT 를 엔드포인트로, REDIS_SSL_ENABLED 를 true 로 바꾼다.
+REDIS_ENDPOINT=redis
+REDIS_PORT=6379
+REDIS_SSL_ENABLED=false
+
+# ---------- JWT ----------
+# Base64 인코딩된 512bit 키. 로컬 값과 반드시 달라야 한다.
+JWT_SECRET=
+ACCESS_TOKEN_EXP=86400000
+REFRESH_TOKEN_EXP=604800000
+
+# ---------- 서비스 간 내부 호출 토큰 ----------
+# 비우면 InternalApiAuthenticationFilter 가 /api/internal/** 전체를 401 로
+# 막는다(fail-closed). 그러면 서비스 간 Feign 호출이 전부 깨지므로 필수다.
+# DLT 재적재 호출에도 이 값을 X-Internal-Token 헤더로 쓴다.
+INTERNAL_SERVICE_TOKEN=
+
+# ---------- 클라이언트 / 쿠키 ----------
+CLIENT_URL=https://comatching.site
+AUTH_COOKIE_SECURE=true
+AUTH_COOKIE_DOMAIN=comatching.site
+AUTH_COOKIE_SAME_SITE=Lax
+DEFAULT_PROFILE_IMAGE_BASE_URL=https://srv.comatching.site/api/public/profile-images/
+
+# ---------- Swagger 노출 스위치 ----------
+# 기본은 꺼짐(변수 미설정). 켜려면 아래 줄의 주석을 풀고 - 값은 빈 문자열이다 -
+# 게이트웨이만 재기동한다:
+#   docker compose -f docker-compose.prod.yml up -d --force-recreate gateway-service
+# 켜도 AuthorizationHeaderFilter 가 붙어 있어 로그인 쿠키가 있어야 열린다.
+# SWAGGER_PATH_PREFIX=
+
+# ---------- DLT 적재 알림 ----------
+# Discord 웹훅 URL(https://discord.com/api/webhooks/<id>/<token>) 또는 Slack.
+# 비우면 로그만 남는다. 이 URL 자체가 비밀값이다.
+DLT_ALERT_WEBHOOK_URL=
+
+# ---------- Gmail SMTP ----------
+SMTP_PASSWORD=
+
+# ---------- AWS S3 ----------
+AWS_ACCESS_KEY=
+AWS_SECRET_KEY=
+AWS_S3_BUCKET=
+
+# ---------- Kakao OAuth2 ----------
+KAKAO_CLIENT_ID=
+KAKAO_CLIENT_SECRET=
+KAKAO_ADMIN_KEY=
+
+# ---------- 아이템 / 주문 ----------
+ORDER_EXPIRE_MINUTES=43200
+PRE_SIGNUP_MATCHING_TICKET_GRANT_ENABLED=true
+PRE_SIGNUP_MATCHING_TICKET_GRANT_QUANTITY=1
+PRE_SIGNUP_MATCHING_TICKET_GRANT_CAMPAIGN_CODE=PRE_SIGNUP_2026

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,182 @@
+# ============================================================
+# main 푸시 -> 깃허브에서 이미지 빌드 -> EC2 가 pull 받아 재기동.
+#
+# 단계가 셋으로 나뉜 이유:
+#   build   Gradle 을 한 번만 돌려 jar 6개를 만든다. 서비스가 6개라고 Gradle 을
+#           6번 돌리면 common-module 컴파일을 6번 반복하게 된다.
+#   images  jar 하나씩 받아 얇은 런타임 이미지로 만들어 GHCR 에 올린다.
+#           서비스끼리 의존이 없으니 6개가 동시에 돈다(matrix).
+#   deploy  EC2 에 SSH 로 들어가 pull 하고 compose 를 다시 올린다.
+#
+# 필요한 저장소 시크릿 (Settings > Secrets and variables > Actions):
+#   EC2_HOST     EC2 퍼블릭 IP 또는 도메인
+#   EC2_USER     ec2-user (Amazon Linux) 또는 ubuntu
+#   EC2_SSH_KEY  EC2 접속용 개인키 전문 (-----BEGIN ... 부터 끝까지)
+#
+# EC2 에서 한 번만 해둘 것 - GHCR 이미지를 받으려면 로그인이 필요하다
+# (레포가 비공개면 패키지도 비공개다):
+#   echo <read:packages 권한 PAT> | docker login ghcr.io -u <깃허브아이디> --password-stdin
+# ============================================================
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  # 코드 변경 없이 다시 배포하고 싶을 때 수동 실행
+  workflow_dispatch:
+
+# 배포가 겹치면 EC2 에서 compose 두 개가 동시에 컨테이너를 만든다.
+# 나중에 들어온 것만 남기고 앞의 것은 취소한다.
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+env:
+  # GHCR 경로는 소문자만 허용한다(레포명은 Comatching5_BE 지만 여기선 소문자).
+  IMAGE_PREFIX: ghcr.io/comatching/comatching5_be
+
+jobs:
+  build:
+    name: jar 빌드 + 테스트
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: chmod +x gradlew
+
+      # build = 컴파일 + 테스트 + bootJar. 테스트가 통과해야 이미지가 만들어진다.
+      # matching-service 는 Testcontainers(MySQL)를, 카프카 IT 는 EmbeddedKafka 를
+      # 쓴다. 둘 다 ubuntu-latest 러너에서 돈다.
+      # 테스트가 발목을 잡으면 이 줄을 `./gradlew bootJar` 로 바꾸면 되지만,
+      # 그러면 검증 없이 운영에 나간다는 뜻이다.
+      - name: 빌드 및 테스트
+        run: ./gradlew build --no-daemon
+
+      - name: 테스트 리포트 보관
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: '*/build/reports/tests/**'
+          retention-days: 7
+
+      - name: jar 보관
+        uses: actions/upload-artifact@v4
+        with:
+          name: boot-jars
+          path: '*/build/libs/*.jar'
+          retention-days: 1
+
+  images:
+    name: 이미지 (${{ matrix.service }})
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      # 한 서비스가 실패해도 나머지는 끝까지 만든다. 어디가 깨졌는지 한 번에 본다.
+      fail-fast: false
+      matrix:
+        service:
+          - gateway-service
+          - user-service
+          - matching-service
+          - chat-service
+          - item-service
+          - notification
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: boot-jars
+          path: jars
+
+      # 컨텍스트에 app.jar 하나만 둔다. 소스 전체를 컨텍스트로 넘기면
+      # 도커 데몬에 수십 MB 를 전송하고 캐시도 쉽게 깨진다.
+      - name: 빌드 컨텍스트 준비
+        run: |
+          set -euo pipefail
+          mkdir -p ci-context
+          cp jars/${{ matrix.service }}/build/libs/*.jar ci-context/app.jar
+          ls -la ci-context
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # 태그 둘을 같이 올린다.
+      #   :latest       사람이 눈으로 볼 때 쓰는 이름
+      #   :<커밋 SHA>   실제로 배포에 쓰는 이름. 어떤 커밋이 떠 있는지가 명확하고,
+      #                 되돌릴 때 예전 SHA 를 그대로 지목할 수 있다.
+      - uses: docker/build-push-action@v6
+        with:
+          context: ci-context
+          file: Dockerfile.ci
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  deploy:
+    name: EC2 배포
+    needs: images
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH 로 pull + 재기동
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd ~/comatching
+
+            # 컴포즈 파일·설정 갱신. .env.prod 는 추적 대상이 아니라 reset 에
+            # 지워지지 않는다(추적되지 않는 파일은 건드리지 않음).
+            git fetch origin main
+            git reset --hard origin/main
+
+            # 배포한 태그를 .env.prod 에 박아 둔다. 나중에 사람이 손으로
+            # docker compose up 을 해도 지금 뜬 것과 같은 버전이 뜬다.
+            if grep -q '^IMAGE_TAG=' .env.prod; then
+              sed -i "s|^IMAGE_TAG=.*|IMAGE_TAG=${{ github.sha }}|" .env.prod
+            else
+              echo "IMAGE_TAG=${{ github.sha }}" >> .env.prod
+            fi
+
+            docker compose -f docker-compose.prod.yml --env-file .env.prod pull
+            # --no-build: EC2 에서 소스를 빌드하지 않는다. 이미지는 이미 만들어져 있다.
+            docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --no-build
+
+            # 배포마다 서비스 6개의 이미지가 새로 쌓인다. prune -f 는 태그
+            # 없는 것만 지우는데, 옛 커밋 SHA 이미지는 태그가 붙어 있어 그대로
+            # 남는다. -a 로 "컨테이너가 쓰지 않는 것"까지 대상에 넣되, 72시간은
+            # 남겨 최근 버전으로 되돌릴 여지를 둔다.
+            docker image prune -af --filter "until=72h"
+
+      - name: 상태 확인
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd ~/comatching
+            docker compose -f docker-compose.prod.yml --env-file .env.prod ps

--- a/.gitignore
+++ b/.gitignore
@@ -50,13 +50,12 @@ bin/
 CLAUDE.md
 scripts
 .idea
-.dockerignore
 docker-compose.yml
-Dockerfile
+# Dockerfile / .dockerignore / docker-compose.prod.yml 은 비밀값이 없는
+# 배포 자산이라 추적한다. 실제 값은 .env.prod 에만 있고 그건 위에서 무시된다.
 /database
 /docs/*
 !/docs/perf-log.md
-docker-compose.prod.yml
 application-docker.yml
 application-secret.yml
 serviceAccountKey.json
@@ -80,3 +79,10 @@ __pycache__/
 *.pyc
 
 _workspace
+
+# SSH 개인키. 레포 폴더에 키를 두는 일이 있어도 커밋되지 않게 막는다.
+*.pem
+*.ppk
+id_rsa
+id_ed25519
+comatching-ec2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+# ============================================================
+# 서비스 6개가 한 파일을 공유한다. 빌드할 대상은 인자로 받는다.
+#   docker build --build-arg SERVICE=user-service -t comatching/user-service .
+# docker-compose.prod.yml 이 서비스마다 이 인자를 넘긴다.
+# ============================================================
+
+# ---------- 빌드 ----------
+FROM eclipse-temurin:17-jdk-jammy AS build
+WORKDIR /workspace
+
+COPY . .
+
+# gradlew 가 Windows 에서 커밋되어 줄바꿈이 CRLF 다. 리눅스 셸은 끝의 캐리지
+# 리턴을 인터프리터 경로의 일부로 읽어서 "bad interpreter: /bin/sh^M" 으로 죽는다.
+RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
+
+# 여기서 6개 서비스의 jar 를 한 번에 만든다. 이 스테이지에 ARG SERVICE 를 두지
+# 않는 것이 핵심이다 - 명령이 서비스마다 동일해야 도커가 이 층을 재사용하고,
+# 그래야 이미지 6개를 빌드할 때 Gradle 이 6번이 아니라 1번만 돈다.
+# vCPU 2개짜리 인스턴스에서 빌드하면 이 차이가 10분 단위로 벌어진다.
+# common-module 은 bootJar 가 꺼져 있어 대상에서 알아서 빠진다.
+#
+# BuildKit 캐시 마운트: 의존성 캐시를 이미지 층에 남기지 않으면서도
+# 재빌드 때 다운로드를 건너뛴다.
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew --no-daemon bootJar
+
+# ---------- 실행 ----------
+FROM eclipse-temurin:17-jre-jammy AS runtime
+ARG SERVICE
+
+# curl: 컴포즈 헬스체크가 /actuator/health 를 찌른다.
+# tzdata: 로그·스케줄러·MySQL serverTimezone 이 모두 KST 기준이다.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl tzdata \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime \
+ && echo "Asia/Seoul" > /etc/timezone \
+ && useradd --system --uid 10001 --shell /usr/sbin/nologin app
+
+WORKDIR /app
+# bootJar 만 실행했으므로 build/libs 에는 실행 가능 jar 하나만 있다
+# (jar 태스크가 만드는 -plain.jar 는 생성되지 않는다).
+COPY --from=build /workspace/${SERVICE}/build/libs/*.jar /app/app.jar
+RUN chown app:app /app/app.jar
+USER app
+
+# -Xmx 를 고정하지 않고 컨테이너 메모리 한도에 비례시킨다. 컴포즈에서
+# mem_limit 만 조정하면 힙이 따라 움직인다.
+# ExitOnOutOfMemoryError: OOM 뒤 좀비로 사는 것보다 죽고 재시작되는 편이 낫다.
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError -Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8"
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+# ============================================================
+# CI 전용 런타임 이미지.
+#
+# Dockerfile 과 나뉘어 있는 이유:
+#   Dockerfile 은 소스에서 jar 까지 스스로 만든다(로컬·EC2 에서 직접 빌드용).
+#   CI 에서는 Gradle 을 이미 한 번 돌려 jar 6개를 만들어 둔 상태라, 이미지마다
+#   Gradle 을 다시 돌리면 같은 일을 6번 한다. 여기서는 만들어진 jar 만 받는다.
+#
+# 빌드 컨텍스트는 app.jar 하나만 든 디렉터리다(워크플로가 만들어 준다):
+#   docker build -f Dockerfile.ci -t <image> ci-context/
+#
+# 아래 런타임 설정은 Dockerfile 의 runtime 스테이지와 같은 내용이다.
+# 한쪽을 고치면 다른 쪽도 같이 고칠 것.
+# ============================================================
+FROM eclipse-temurin:17-jre-jammy
+
+# curl: 컴포즈 헬스체크가 /actuator/health 를 찌른다.
+# tzdata: 로그·스케줄러·MySQL serverTimezone 이 모두 KST 기준이다.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl tzdata \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime \
+ && echo "Asia/Seoul" > /etc/timezone \
+ && useradd --system --uid 10001 --shell /usr/sbin/nologin app
+
+WORKDIR /app
+COPY app.jar /app/app.jar
+RUN chown app:app /app/app.jar
+USER app
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError -Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8"
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/chat-service/src/main/resources/application-aws.yml
+++ b/chat-service/src/main/resources/application-aws.yml
@@ -22,16 +22,23 @@ spring:
       host: ${REDIS_ENDPOINT}
       port: 6379
       ssl:
-        enabled: true
+        # ElastiCache(전송 중 암호화 켬)면 true, EC2 컨테이너 Redis 면 false.
+        enabled: ${REDIS_SSL_ENABLED:true}
 
   kafka:
     bootstrap-servers: kafka:29092
+    admin:
+      # KafkaAdmin 은 기동 시 선언된 토픽을 만든다. 기본값(false)이면 브로커에
+      # 못 붙어도 경고만 남기고 앱이 정상 기동해서, 토픽이 없는 채로 "성공한"
+      # 배포가 되고 발행·구독이 런타임에 조용히 실패한다. true 면 그 자리에서
+      # 컨텍스트 로딩이 깨져 배포 시점에 드러난다.
+      fail-fast: true
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
       group-id: chat-service-group
-      auto-offset-reset: latest
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
@@ -60,6 +67,11 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      # base 프로파일의 always 를 여기서 덮는다. 상속되면 구성요소 상태가
+      # 인증 없이 그대로 드러난다.
+      show-details: never
 
 # 재시도를 다 쓴 메시지를 옮길 DLT 토픽(<토픽>.DLT)을 기동 시 만든다.
 # 이 서비스가 소비하는 토픽만 적는다.

--- a/chat-service/src/main/resources/application.yml
+++ b/chat-service/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
       group-id: chat-service-group
-      auto-offset-reset: latest
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 

--- a/common-module/src/main/java/com/comatching/common/config/kafka/KafkaConsumerConfig.java
+++ b/common-module/src/main/java/com/comatching/common/config/kafka/KafkaConsumerConfig.java
@@ -51,13 +51,19 @@ public class KafkaConsumerConfig {
 		return factory;
 	}
 
-	// 이 팩토리는 yml 의 spring.kafka.consumer.* 를 읽지 않으므로(수동 구성)
-	// auto.offset.reset 을 명시하지 않으면 클라이언트 기본값 latest 가 적용된다.
-	// latest 는 파티션 증설과 만나면 유실이 된다: 새 파티션에는 커밋 오프셋이
-	// 없어서, 컨슈머 그룹이 그 파티션을 처음 배정받기 전에 발행된 메시지를
-	// 로그 끝으로 건너뛴다(탈퇴 메일 누락, 후보 tombstone 미기록). earliest 는
-	// 커밋 오프셋이 있는 기존 파티션에는 영향이 없고 새 파티션만 처음부터 읽는다.
-	private static final String AUTO_OFFSET_RESET = "earliest";
+	// 이 팩토리는 spring.kafka.consumer.* 를 자동설정으로 받지 않고(수동 구성)
+	// 필요한 값만 골라 읽는다. auto.offset.reset 은 yml 이 진실이 되어야 한다 -
+	// 예전에는 여기에 상수로 박혀 있어서, yml 에 latest 라고 적어둔 서비스도
+	// 실제로는 earliest 로 돌았다. 설정 파일과 실제 동작이 어긋나면 나중에
+	// yml 을 고친 사람이 아무 일도 일어나지 않는 이유를 찾지 못한다.
+	//
+	// 기본값을 earliest 로 두는 이유: latest 는 파티션 증설과 만나면 유실이 된다.
+	// 새 파티션에는 커밋 오프셋이 없어서, 컨슈머 그룹이 그 파티션을 처음
+	// 배정받기 전에 발행된 메시지를 로그 끝으로 건너뛴다(탈퇴 메일 누락, 후보
+	// tombstone 미기록). earliest 는 커밋 오프셋이 있는 기존 파티션에는 영향이
+	// 없고 새 파티션만 처음부터 읽는다. 바꾸려면 그 대가를 알고 바꿔야 한다.
+	@Value("${spring.kafka.consumer.auto-offset-reset:earliest}")
+	private String autoOffsetReset;
 
 	public static final String DLT_SUFFIX = ".DLT";
 
@@ -149,7 +155,7 @@ public class KafkaConsumerConfig {
 		Map<String, Object> config = new HashMap<>();
 		config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, AUTO_OFFSET_RESET);
+		config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
 		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		return withMetrics(new DefaultKafkaConsumerFactory<>(config));
@@ -160,7 +166,7 @@ public class KafkaConsumerConfig {
 		Map<String, Object> config = new HashMap<>();
 		config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, AUTO_OFFSET_RESET);
+		config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
 		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		// JsonDeserializer 를 그대로 쓰면 역직렬화 실패가 poll 단계에서 터진다.
 		// 그 단계에는 에러 핸들러가 개입할 수 없어서 오프셋이 넘어가지 못하고

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,345 @@
+# ============================================================
+# 운영(EC2 단일 인스턴스, t3.large) 구성.
+#
+# 기동 방식이 둘이고, image 와 build 를 함께 적어 둔 이유가 그것이다.
+#
+#   (1) CI 배포 - GitHub Actions 가 만들어 올린 이미지를 받아 띄운다.
+#       docker compose -f docker-compose.prod.yml --env-file .env.prod pull
+#       docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --no-build
+#
+#   (2) 이 자리에서 빌드 - CI 없이 급하게 올릴 때. 소스 전체가 있어야 한다.
+#       docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build
+#
+# 어떤 버전이 떠 있는지는 .env.prod 의 IMAGE_TAG 가 말해준다(배포 때 CI 가 커밋
+# SHA 로 갱신한다). 되돌리려면 그 값을 예전 SHA 로 바꾸고 (1) 을 다시 하면 된다.
+#
+# MySQL 은 RDS 라 여기 없다. Redis/MongoDB/Kafka 는 이 인스턴스의 컨테이너다.
+# 외부에 여는 포트는 게이트웨이 8080 하나뿐이다 - 나머지가 호스트에 노출되면
+# 서비스들이 X-Member-* 헤더를 그대로 믿기 때문에 인증이 무의미해진다.
+# ============================================================
+name: comatching
+
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+
+x-app: &app
+  env_file:
+    - .env.prod
+  environment:
+    SPRING_PROFILES_ACTIVE: aws
+  restart: unless-stopped
+  networks: [comatching]
+  logging: *logging
+
+networks:
+  comatching:
+    driver: bridge
+
+volumes:
+  kafka-data:
+  mongo-data:
+  redis-data:
+
+services:
+
+  # ---------- 인프라 ----------
+
+  # named volume 은 이미지에 없는 경로에 붙으면 root 소유로 만들어진다.
+  # apache/kafka 는 uid 1000(appuser)으로 돌아서 그대로면 로그 디렉터리에
+  # 쓰지 못하고 죽는다. 한 번만 돌고 끝나는 권한 보정이다.
+  kafka-data-init:
+    image: busybox:1.36
+    container_name: comatching-kafka-data-init
+    command: sh -c "mkdir -p /data && chown -R 1000:1000 /data && chmod -R u+rwX,g+rwX /data"
+    volumes:
+      - kafka-data:/data
+    restart: "no"
+    logging: *logging
+
+  kafka:
+    image: apache/kafka:3.9.0
+    container_name: comatching-kafka
+    restart: unless-stopped
+    networks: [comatching]
+    depends_on:
+      kafka-data-init:
+        condition: service_completed_successfully
+    environment:
+      # KRaft 단독 모드. broker 와 controller 를 한 프로세스가 겸하고 쿼럼은
+      # 자기 자신이다. Zookeeper 는 필요 없다(3.5 deprecated, 4.0 제거).
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      # 로컬 컴포즈는 localhost:9092 를 광고한다. 그대로 쓰면 클라이언트가
+      # 부트스트랩 직후 localhost 로 리다이렉트되어 전부 실패한다.
+      # 앱들의 aws 프로파일이 kafka:29092 를 보므로 그대로 광고한다.
+      KAFKA_LISTENERS: INTERNAL://:29092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      # 토픽은 kafka-topic-init 이 스펙대로 만든다. auto-create 를 켜두면
+      # 오타 난 토픽 이름이 파티션 1개짜리로 조용히 생겨 원인을 찾기 어렵다.
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 3000
+      # /tmp 가 아니라 볼륨 위에 둔다. DLT 에 세워둔 메시지와 컨슈머 오프셋이
+      # 컨테이너 재생성에 살아남아야 재적재가 의미를 갖는다.
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      KAFKA_HEAP_OPTS: "-Xmx1g -Xms512m"
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    mem_limit: 1280m
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server kafka:29092 >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 30s
+    logging: *logging
+
+  # auto-create 를 껐으므로 토픽을 누가 만들지 정해야 한다.
+  # 코드가 선언하는 토픽은 member-withdraw / profile-updates(matching-service)와
+  # *.DLT 뿐이고, member-signup · matching-success-topic · chat-notification 은
+  # 아무도 선언하지 않는다. 게다가 토픽을 선언하는 서비스보다 발행하는 서비스가
+  # 먼저 뜨면 발행이 실패한다. 여기서 전부 미리 만들어 순서 문제를 없앤다.
+  kafka-topic-init:
+    image: apache/kafka:3.9.0
+    container_name: comatching-kafka-topic-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    networks: [comatching]
+    restart: "no"
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        set -euo pipefail
+        T=/opt/kafka/bin/kafka-topics.sh
+        BS=kafka:29092
+        RETENTION_1D=86400000
+
+        # 파티션 수는 코드의 선언과 일치시킨다. KafkaTopicConfig 가 기동 시
+        # 파티션이 모자라면 늘리지만, 미리 맞춰두면 그 경로를 탈 일이 없다.
+        $$T --bootstrap-server $$BS --create --if-not-exists --replication-factor 1 --partitions 1 --topic member-signup
+        $$T --bootstrap-server $$BS --create --if-not-exists --replication-factor 1 --partitions 1 --topic matching-success-topic
+        $$T --bootstrap-server $$BS --create --if-not-exists --replication-factor 1 --partitions 1 --topic chat-notification
+        $$T --bootstrap-server $$BS --create --if-not-exists --replication-factor 1 --partitions 3 --topic member-withdraw --config retention.ms=$$RETENTION_1D
+        $$T --bootstrap-server $$BS --create --if-not-exists --replication-factor 1 --partitions 3 --topic profile-updates --config retention.ms=$$RETENTION_1D
+
+        # DLT 는 사람이 열어 보는 저용량 토픽이라 파티션 1개.
+        # retention 은 브로커 기본(7일)을 쓴다 - 원본(1일)보다 길어야 고치고
+        # 되돌릴 시간이 남는다.
+        for t in member-signup member-withdraw profile-updates matching-success-topic chat-notification; do
+          $$T --bootstrap-server $$BS --create --if-not-exists --replication-factor 1 --partitions 1 --topic $$t.DLT
+        done
+
+        echo "=== 토픽 준비 완료 ==="
+        $$T --bootstrap-server $$BS --list
+    logging: *logging
+
+  mongodb:
+    image: mongo:7
+    container_name: comatching-mongodb
+    restart: unless-stopped
+    networks: [comatching]
+    # 인증 없이 뜬다. 컨테이너 네트워크 밖으로 포트를 열지 않는 것이 유일한
+    # 방어선이므로 ports 를 추가하지 말 것.
+    command: ["--wiredTigerCacheSizeGB", "0.25"]
+    volumes:
+      - mongo-data:/data/db
+    mem_limit: 768m
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+    logging: *logging
+
+  redis:
+    image: redis:7-alpine
+    container_name: comatching-redis
+    restart: unless-stopped
+    networks: [comatching]
+    # maxmemory-policy 가 noeviction 인 것이 중요하다. allkeys-lru 로 두면
+    # 메모리가 찰 때 액세스 토큰 denylist 키가 조용히 evict 되고, 로그아웃으로
+    # 취소한 토큰이 다시 유효해진다(액세스 토큰 만료가 24시간이라 창이 길다).
+    # noeviction 은 대신 쓰기가 실패해서 시끄럽게 드러난다.
+    # appendonly: 재기동에도 denylist·리프레시 토큰이 살아남아야 한다.
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --maxmemory
+      - 256mb
+      - --maxmemory-policy
+      - noeviction
+    volumes:
+      - redis-data:/data
+    mem_limit: 320m
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 20
+    logging: *logging
+
+  # ---------- 애플리케이션 ----------
+
+  user-service:
+    <<: *app
+    image: ${IMAGE_PREFIX:-ghcr.io/comatching/comatching5_be}/user-service:${IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: user-service
+    container_name: comatching-user-service
+    depends_on:
+      kafka-topic-init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    mem_limit: 768m
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 120s
+
+  matching-service:
+    <<: *app
+    image: ${IMAGE_PREFIX:-ghcr.io/comatching/comatching5_be}/matching-service:${IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: matching-service
+    container_name: comatching-matching-service
+    depends_on:
+      kafka-topic-init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    mem_limit: 640m
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9001/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 120s
+
+  chat-service:
+    <<: *app
+    image: ${IMAGE_PREFIX:-ghcr.io/comatching/comatching5_be}/chat-service:${IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: chat-service
+    container_name: comatching-chat-service
+    depends_on:
+      kafka-topic-init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+    mem_limit: 576m
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9003/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 120s
+
+  item-service:
+    <<: *app
+    image: ${IMAGE_PREFIX:-ghcr.io/comatching/comatching5_be}/item-service:${IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: item-service
+    container_name: comatching-item-service
+    depends_on:
+      kafka-topic-init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    mem_limit: 640m
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9006/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 120s
+
+  notification:
+    <<: *app
+    image: ${IMAGE_PREFIX:-ghcr.io/comatching/comatching5_be}/notification:${IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: notification
+    container_name: comatching-notification
+    depends_on:
+      kafka-topic-init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    mem_limit: 576m
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9005/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 120s
+
+  # 마지막에 뜬다. 뒤쪽 서비스가 준비되기 전에 게이트웨이가 트래픽을 받으면
+  # 첫 요청들이 502 로 떨어진다.
+  gateway-service:
+    <<: *app
+    image: ${IMAGE_PREFIX:-ghcr.io/comatching/comatching5_be}/gateway-service:${IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE: gateway-service
+    container_name: comatching-gateway
+    depends_on:
+      redis:
+        condition: service_healthy
+      user-service:
+        condition: service_healthy
+      matching-service:
+        condition: service_healthy
+      chat-service:
+        condition: service_healthy
+      item-service:
+        condition: service_healthy
+      notification:
+        condition: service_healthy
+    # 루프백에만 바인딩한다. TLS 종단이 같은 호스트의 nginx 라서 외부가 8080 에
+    # 직접 닿을 이유가 없다. 0.0.0.0 으로 열면 보안그룹 하나가 유일한 방어선이
+    # 되는데, 뒤쪽 서비스들이 X-Member-* 헤더를 그대로 믿기 때문에 그 한 겹이
+    # 뚫리면 인증이 통째로 무의미해진다.
+    ports:
+      - "127.0.0.1:8080:8080"
+    mem_limit: 512m
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 90s

--- a/gateway-service/src/main/resources/application-aws.yml
+++ b/gateway-service/src/main/resources/application-aws.yml
@@ -11,7 +11,8 @@ spring:
       host: ${REDIS_ENDPOINT}
       port: ${REDIS_PORT:6379}
       ssl:
-        enabled: ${SPRING_DATA_REDIS_SSL_ENABLED:true}
+        # ElastiCache(전송 중 암호화 켬)면 true, EC2 컨테이너 Redis 면 false.
+        enabled: ${REDIS_SSL_ENABLED:true}
 
   cloud:
     gateway:
@@ -21,10 +22,11 @@ spring:
           globalcors:
             cors-configurations:
               '[/**]':
+                # 운영에는 실제 프론트 출처만 둔다. allowCredentials: true 와
+                # localhost 출처를 함께 두면 로컬에서 뜬 아무 페이지나 사용자의
+                # 쿠키를 실어 이 API 를 부를 수 있다.
                 allowedOrigins:
                   - "https://comatching.site"
-                  - "http://localhost:3000"
-                  - "http://localhost:5173"
                 allowedMethods: [GET, POST, PUT, PATCH, DELETE, OPTIONS]
                 allowedHeaders: "*"
                 allowCredentials: true
@@ -55,12 +57,24 @@ spring:
               predicates:
                 - Path=/api/auth/login, /api/auth/signup, /api/auth/signup/nickname/availability, /api/auth/participants, /api/auth/participants/**, /api/auth/email/**, /api/auth/password/code, /api/auth/reissue, /api/profile/tags, /api/hobbies/categories, /api/public/profile-images/**, /oauth2/**, /login/**, /default-ui.css
 
+            # ── Swagger 노출 스위치 (기본: 꺼짐) ────────────────────────────
+            #   끄기: SWAGGER_PATH_PREFIX 미설정
+            #         -> Path 가 /__swagger-off__/user-doc/** 이 되어 사실상 도달 불가
+            #   켜기: .env.prod 에 SWAGGER_PATH_PREFIX= (빈 값) 을 넣고 게이트웨이만 재기동
+            #         -> Path 가 /user-doc/** 로 복원된다
+            #
+            # 켠 상태에서도 AuthorizationHeaderFilter 는 반드시 붙어 있어야 한다.
+            # 이 필터만이 클라이언트가 보낸 X-Member-* 헤더를 지우고 JWT 에서 다시
+            # 채운다. RewritePath 는 접두사만 떼고 임의 경로를 그대로 뒤로 넘기므로,
+            # 필터가 없으면 /user-doc/api/... 로 아무 엔드포인트나 부르면서 헤더를
+            # 위조할 수 있다 - 게이트웨이 인증이 통째로 우회된다.
             - id: user-service-swagger
               uri: http://user-service:9000
               predicates:
-                - Path=/user-doc/**
+                - Path=${SWAGGER_PATH_PREFIX:/__swagger-off__}/user-doc/**
               filters:
-                - RewritePath=/user-doc/(?<segment>.*), /$\{segment}
+                - AuthorizationHeaderFilter
+                - RewritePath=${SWAGGER_PATH_PREFIX:/__swagger-off__}/user-doc/(?<segment>.*), /$\{segment}
 
             - id: matching-service
               uri: http://matching-service:9001
@@ -69,12 +83,14 @@ spring:
               filters:
                 - AuthorizationHeaderFilter
 
+            # Swagger 스위치 - 위 user-service-swagger 주석 참고.
             - id: matching-service-swagger
               uri: http://matching-service:9001
               predicates:
-                - Path=/matching-doc/**
+                - Path=${SWAGGER_PATH_PREFIX:/__swagger-off__}/matching-doc/**
               filters:
-                - RewritePath=/matching-doc/(?<segment>.*), /$\{segment}
+                - AuthorizationHeaderFilter
+                - RewritePath=${SWAGGER_PATH_PREFIX:/__swagger-off__}/matching-doc/(?<segment>.*), /$\{segment}
 
             - id: chat-service
               uri: http://chat-service:9003
@@ -83,12 +99,14 @@ spring:
               filters:
                 - AuthorizationHeaderFilter
 
+            # Swagger 스위치 - 위 user-service-swagger 주석 참고.
             - id: chat-service-swagger
               uri: http://chat-service:9003
               predicates:
-                - Path=/chat-doc/**
+                - Path=${SWAGGER_PATH_PREFIX:/__swagger-off__}/chat-doc/**
               filters:
-                - RewritePath=/chat-doc/(?<segment>.*), /$\{segment}
+                - AuthorizationHeaderFilter
+                - RewritePath=${SWAGGER_PATH_PREFIX:/__swagger-off__}/chat-doc/(?<segment>.*), /$\{segment}
 
             - id: item-service
               uri: http://item-service:9006
@@ -123,3 +141,8 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      # 게이트웨이의 8080 은 외부에 열려 있다. always 로 두면 인증 없이
+      # DB/Redis 구성요소 상태와 접속 정보 일부가 그대로 드러난다.
+      show-details: never

--- a/item-service/src/main/resources/application-aws.yml
+++ b/item-service/src/main/resources/application-aws.yml
@@ -26,7 +26,10 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      # 첫 배포는 JPA_DDL_AUTO=create 로 스키마를 만들고, 그 뒤에는 값을 빼서
+      # validate 로 돌린다. update 를 상시로 두면 엔티티를 고칠 때마다 앱이
+      # 운영 스키마를 말없이 바꾸고, 그 변경은 되돌릴 수단이 없다.
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     show-sql: false
 
   data:
@@ -34,10 +37,17 @@ spring:
       host: ${REDIS_ENDPOINT}
       port: 6379
       ssl:
-        enabled: true
+        # ElastiCache(전송 중 암호화 켬)면 true, EC2 컨테이너 Redis 면 false.
+        enabled: ${REDIS_SSL_ENABLED:true}
 
   kafka:
     bootstrap-servers: kafka:29092
+    admin:
+      # KafkaAdmin 은 기동 시 선언된 토픽을 만든다. 기본값(false)이면 브로커에
+      # 못 붙어도 경고만 남기고 앱이 정상 기동해서, 토픽이 없는 채로 "성공한"
+      # 배포가 되고 발행·구독이 런타임에 조용히 실패한다. true 면 그 자리에서
+      # 컨텍스트 로딩이 깨져 배포 시점에 드러난다.
+      fail-fast: true
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
@@ -87,3 +97,8 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      # base 프로파일의 always 를 여기서 덮는다. 상속되면 구성요소 상태가
+      # 인증 없이 그대로 드러난다.
+      show-details: never

--- a/matching-service/src/main/resources/application-aws.yml
+++ b/matching-service/src/main/resources/application-aws.yml
@@ -30,7 +30,10 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      # 첫 배포는 JPA_DDL_AUTO=create 로 스키마를 만들고, 그 뒤에는 값을 빼서
+      # validate 로 돌린다. update 를 상시로 두면 엔티티를 고칠 때마다 앱이
+      # 운영 스키마를 말없이 바꾸고, 그 변경은 되돌릴 수단이 없다.
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     show-sql: false
     properties:
       hibernate:
@@ -41,13 +44,20 @@ spring:
       host: ${REDIS_ENDPOINT}
       port: 6379
       ssl:
-        enabled: true
+        # ElastiCache(전송 중 암호화 켬)면 true, EC2 컨테이너 Redis 면 false.
+        enabled: ${REDIS_SSL_ENABLED:true}
 
   kafka:
     bootstrap-servers: kafka:29092
+    admin:
+      # KafkaAdmin 은 기동 시 선언된 토픽을 만든다. 기본값(false)이면 브로커에
+      # 못 붙어도 경고만 남기고 앱이 정상 기동해서, 토픽이 없는 채로 "성공한"
+      # 배포가 되고 발행·구독이 런타임에 조용히 실패한다. true 면 그 자리에서
+      # 컨텍스트 로딩이 깨져 배포 시점에 드러난다.
+      fail-fast: true
     consumer:
       group-id: matching-service-group
-      auto-offset-reset: latest
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
@@ -76,6 +86,11 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      # base 프로파일의 always 를 여기서 덮는다. 상속되면 구성요소 상태가
+      # 인증 없이 그대로 드러난다.
+      show-details: never
 
 # 재시도를 다 쓴 메시지를 옮길 DLT 토픽(<토픽>.DLT)을 기동 시 만든다.
 # 이 서비스가 소비하는 토픽만 적는다.

--- a/matching-service/src/main/resources/application.yml
+++ b/matching-service/src/main/resources/application.yml
@@ -44,7 +44,7 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       group-id: matching-service-group
-      auto-offset-reset: latest
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 

--- a/notification/src/main/resources/application-aws.yml
+++ b/notification/src/main/resources/application-aws.yml
@@ -8,12 +8,19 @@ spring:
       host: ${REDIS_ENDPOINT}
       port: 6379
       ssl:
-        enabled: true
+        # ElastiCache(전송 중 암호화 켬)면 true, EC2 컨테이너 Redis 면 false.
+        enabled: ${REDIS_SSL_ENABLED:true}
   kafka:
     bootstrap-servers: kafka:29092
+    admin:
+      # KafkaAdmin 은 기동 시 선언된 토픽을 만든다. 기본값(false)이면 브로커에
+      # 못 붙어도 경고만 남기고 앱이 정상 기동해서, 토픽이 없는 채로 "성공한"
+      # 배포가 되고 발행·구독이 런타임에 조용히 실패한다. true 면 그 자리에서
+      # 컨텍스트 로딩이 깨져 배포 시점에 드러난다.
+      fail-fast: true
     consumer:
       group-id: notification-group
-      auto-offset-reset: latest
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
     producer:
@@ -37,6 +44,11 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      # base 프로파일의 always 를 여기서 덮는다. 상속되면 구성요소 상태가
+      # 인증 없이 그대로 드러난다.
+      show-details: never
 
 # 재시도를 다 쓴 메시지를 옮길 DLT 토픽(<토픽>.DLT)을 기동 시 만든다.
 # 이 서비스가 소비하는 토픽만 적는다.

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     bootstrap-servers: localhost:9092
     consumer:
       group-id: notification-group
-      auto-offset-reset: latest
+      auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
     producer:

--- a/user-service/src/main/resources/application-aws.yml
+++ b/user-service/src/main/resources/application-aws.yml
@@ -47,7 +47,10 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      # 첫 배포는 JPA_DDL_AUTO=create 로 스키마를 만들고, 그 뒤에는 값을 빼서
+      # validate 로 돌린다. update 를 상시로 두면 엔티티를 고칠 때마다 앱이
+      # 운영 스키마를 말없이 바꾸고, 그 변경은 되돌릴 수단이 없다.
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     show-sql: false
     properties:
       default_batch_fetch_size: 100
@@ -57,10 +60,17 @@ spring:
       host: ${REDIS_ENDPOINT}
       port: 6379
       ssl:
-        enabled: true
+        # ElastiCache(전송 중 암호화 켬)면 true, EC2 컨테이너 Redis 면 false.
+        enabled: ${REDIS_SSL_ENABLED:true}
 
   kafka:
     bootstrap-servers: kafka:29092
+    admin:
+      # KafkaAdmin 은 기동 시 선언된 토픽을 만든다. 기본값(false)이면 브로커에
+      # 못 붙어도 경고만 남기고 앱이 정상 기동해서, 토픽이 없는 채로 "성공한"
+      # 배포가 되고 발행·구독이 런타임에 조용히 실패한다. true 면 그 자리에서
+      # 컨텍스트 로딩이 깨져 배포 시점에 드러난다.
+      fail-fast: true
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
@@ -136,3 +146,8 @@ management:
     web:
       exposure:
         include: health
+  endpoint:
+    health:
+      # base 프로파일의 always 를 여기서 덮는다. 상속되면 구성요소 상태가
+      # 인증 없이 그대로 드러난다.
+      show-details: never


### PR DESCRIPTION
EC2 배포를 앞두고 운영 설정을 점검하다 인증 우회 경로를 발견해 먼저 막았고,
이어서 컨테이너 배포 자산과 CI 파이프라인을 붙였다.

## 인증 우회 차단

게이트웨이의 `/user-doc` `/matching-doc` `/chat-doc` 라우트는 RewritePath 로
접두사만 떼고 임의 경로를 그대로 뒤로 넘기는데 `AuthorizationHeaderFilter`
가 붙어 있지 않았다. 이 필터만이 클라이언트가 보낸 `X-Member-*` 를 지우고
JWT 에서 다시 채우고, 뒤쪽 서비스들은 `anyRequest().permitAll()` 에 그 헤더를
그대로 믿는다. 헤더만 지어내면 아무 회원이나 사칭할 수 있는 상태였다.

필터를 붙이고 `SWAGGER_PATH_PREFIX` 로 켜고 끌 수 있게 하되 기본은 꺼둔다.

## 함께 정리한 운영 기본값

- CORS 에서 localhost 출처 제거
- `ddl-auto` 를 `JPA_DDL_AUTO`(기본 `validate`)로. 첫 배포만 `create`
- `health.show-details` 를 `never` 로. base 의 `always` 가 상속되고 있었다
- Redis `ssl.enabled` 를 환경변수로 (ElastiCache ↔ 컨테이너 전환)
- `kafka.admin.fail-fast` 활성화
- `auto-offset-reset` 을 코드 상수에서 yml 설정으로. yml 에 `latest` 라고
  적힌 서비스도 실제로는 `earliest` 로 돌고 있었다 (동작 변화 없음)

## 배포 구성

MySQL 은 RDS 유지, Redis 는 비용 때문에 ElastiCache 에서 컨테이너로. Kafka ·
MongoDB 도 같은 인스턴스. 외부 노출은 게이트웨이 8080 하나이고 `127.0.0.1`
에만 바인딩한다(같은 호스트 nginx 가 TLS 종단).

배포에서 물릴 지점들을 미리 막았다:
- Kafka 로그를 `/tmp` 에서 볼륨으로. DLT 메시지와 컨슈머 오프셋이 컨테이너
  재생성에 살아남아야 재적재가 의미를 갖는다
- advertised listener 를 `kafka:29092` 로 (로컬 설정 그대로면 전부 실패)
- auto-create 를 끄고 `kafka-topic-init` 이 토픽 10개를 선행 생성.
  `member-signup` 등 3개는 코드 어디에도 선언이 없었고, 발행 서비스가 토픽
  선언 서비스보다 먼저 뜨는 순서 문제도 사라진다
- Redis `maxmemory-policy` 를 `noeviction` 으로. `allkeys-lru` 면 토큰
  denylist 가 evict 되어 취소한 토큰이 되살아난다

## CI

`main` 푸시 → Gradle 1회 빌드(테스트 포함) → jar 6개를 이미지로 만들어 GHCR
push → EC2 가 pull 하고 재기동. 서비스마다 도커 빌드를 돌리면 common-module
을 6번 컴파일하므로 jar 빌드와 이미지 빌드를 분리했다. 배포는 커밋 SHA 로
핀하고 `.env.prod` 의 `IMAGE_TAG` 에 기록한다.

## 남은 것

- notification 은 `@ComponentScan` 대신 `@Import` 로 common 을 좁게 가져와서
  `KafkaDltRedriveController` 와 `InternalApiAuthenticationFilter` 가 등록되지
  않는다. DLT 는 쌓이고 알림도 오는데 되돌릴 엔드포인트가 없다. 별도 처리
- `serviceAccountKey.json` 이 레포에 없어 FCM 초기화가 실패한다(예외를 삼켜
  기동은 정상). 푸시 알림을 쓰려면 CI 에 주입 경로가 필요하다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
