### PR TITLE
CI: jar 선택 오류 수정, 테스트를 PR 단계로 이동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@
 # 단계가 셋으로 나뉜 이유:
 #   build   Gradle 을 한 번만 돌려 jar 6개를 만든다. 서비스가 6개라고 Gradle 을
 #           6번 돌리면 common-module 컴파일을 6번 반복하게 된다.
+#           테스트는 여기서 돌리지 않는다 - PR 시점에 test.yml 이 이미 돌렸다.
+#           배포를 붙잡고 다시 도는 것은 같은 검증을 두 번 하는 셈이다.
 #   images  jar 하나씩 받아 얇은 런타임 이미지로 만들어 GHCR 에 올린다.
 #           서비스끼리 의존이 없으니 6개가 동시에 돈다(matrix).
 #   deploy  EC2 에 SSH 로 들어가 pull 하고 compose 를 다시 올린다.
@@ -37,7 +39,7 @@ env:
 
 jobs:
   build:
-    name: jar 빌드 + 테스트
+    name: jar 빌드
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,21 +53,14 @@ jobs:
 
       - run: chmod +x gradlew
 
-      # build = 컴파일 + 테스트 + bootJar. 테스트가 통과해야 이미지가 만들어진다.
-      # matching-service 는 Testcontainers(MySQL)를, 카프카 IT 는 EmbeddedKafka 를
-      # 쓴다. 둘 다 ubuntu-latest 러너에서 돈다.
-      # 테스트가 발목을 잡으면 이 줄을 `./gradlew bootJar` 로 바꾸면 되지만,
-      # 그러면 검증 없이 운영에 나간다는 뜻이다.
-      - name: 빌드 및 테스트
-        run: ./gradlew build --no-daemon
-
-      - name: 테스트 리포트 보관
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-reports
-          path: '*/build/reports/tests/**'
-          retention-days: 7
+      # bootJar 만 돌린다. `build` 를 쓰면 테스트까지 다시 도는데, 그 검증은
+      # PR 단계(test.yml)에서 이미 끝났다.
+      #
+      # 다만 build/libs 에 jar 가 하나만 생기지는 않는다 - Spring Boot 는
+      # bootJar(실행 가능)와 별개로 jar 태스크가 -plain.jar 를 만들 수 있어,
+      # 아래 이미지 잡에서 실행 가능한 쪽을 골라낸다.
+      - name: jar 빌드
+        run: ./gradlew bootJar --no-daemon
 
       - name: jar 보관
         uses: actions/upload-artifact@v4
@@ -102,11 +97,23 @@ jobs:
 
       # 컨텍스트에 app.jar 하나만 둔다. 소스 전체를 컨텍스트로 넘기면
       # 도커 데몬에 수십 MB 를 전송하고 캐시도 쉽게 깨진다.
+      #
+      # -plain.jar 를 걸러내는 이유: `./gradlew build` 는 bootJar 와 jar 를
+      # 둘 다 돌려서 build/libs 에 jar 가 두 개 생긴다(실행 가능한 것과
+      # 클래스만 든 -plain). 그대로 cp 하면 대상이 디렉터리가 아니라고 실패하고,
+      # 설령 통과해도 어느 쪽이 복사될지 알 수 없다.
       - name: 빌드 컨텍스트 준비
         run: |
           set -euo pipefail
           mkdir -p ci-context
-          cp jars/${{ matrix.service }}/build/libs/*.jar ci-context/app.jar
+          JAR=$(find "jars/${{ matrix.service }}/build/libs" -name '*.jar' ! -name '*-plain.jar')
+          COUNT=$(echo "$JAR" | grep -c . || true)
+          if [ "$COUNT" -ne 1 ]; then
+            echo "실행 가능한 jar 가 정확히 하나여야 하는데 ${COUNT}개다:"
+            ls -la "jars/${{ matrix.service }}/build/libs"
+            exit 1
+          fi
+          cp "$JAR" ci-context/app.jar
           ls -la ci-context
 
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+# ============================================================
+# PR 을 열거나 갱신하면 테스트를 돌린다.
+#
+# 배포 워크플로(deploy.yml)에서 테스트를 뺀 대신 여기로 옮겼다. 검증이
+# 사라진 게 아니라 시점이 앞당겨진 것이다 - main 에 머지된 뒤 배포를
+# 붙잡고 있는 대신, PR 을 보고 있는 동안 백그라운드로 돌아간다.
+#
+# 이 검증이 실제로 게이트가 되려면 브랜치 보호가 필요하다:
+#   Settings > Branches > main > Require status checks to pass
+#   에서 "테스트" 체크를 필수로 지정한다. 없으면 빨간 PR 도 머지된다.
+# ============================================================
+name: test
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# PR 에 새 커밋을 올리면 직전 실행은 의미가 없다. 취소해서 러너를 아낀다.
+concurrency:
+  group: test-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: 테스트
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: chmod +x gradlew
+
+      # matching-service 는 Testcontainers(MySQL)를, 카프카 IT 는
+      # EmbeddedKafka 를 쓴다. 둘 다 ubuntu-latest 러너에서 돈다.
+      - name: 테스트
+        run: ./gradlew test --no-daemon
+
+      # 실패했을 때만이 아니라 항상 올린다. 통과했지만 오래 걸린 테스트를
+      # 찾아볼 때도 리포트가 필요하다.
+      - name: 테스트 리포트 보관
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: '*/build/reports/tests/**'
+          retention-days: 7


### PR DESCRIPTION
첫 배포에서 이미지 잡 6개가 전부 같은 지점에서 실패했다.

## jar 선택 오류

`./gradlew build` 는 `bootJar` 와 `jar` 를 둘 다 돌린다. Spring Boot 는
후자로 `-plain.jar` 를 만들기 때문에 `build/libs` 에 jar 가 두 개다.

```
user-service-0.0.1-SNAPSHOT.jar          실행 가능
user-service-0.0.1-SNAPSHOT-plain.jar    클래스만
```

`cp jars/<svc>/build/libs/*.jar ci-context/app.jar` 는 원본이 둘이면
"대상이 디렉터리가 아니다"로 실패한다. 실행 가능한 쪽만 고르고, 결과가
하나가 아니면 디렉터리 목록과 함께 명확히 실패하도록 바꿨다. 조용히
엉뚱한 jar 가 이미지에 들어가는 것보다 낫다.

## 테스트를 PR 단계로

배포 워크플로에서 테스트를 빼고 `test.yml` 로 옮겼다.

측정값이 근거다. `jar 빌드 + 테스트` 잡이 345초였는데, 테스트를 빼도
컴파일(모듈 7개 + QueryDSL APT)은 그대로라 2~3분쯤 줄어들 뿐이었다.
전체 파이프라인이 빌드·이미지·배포 합쳐 약 14분이니 테스트는 병목이
아니다. 그래서 검증을 없애는 대신 시점만 앞으로 옮겼다 - main 에 머지된
뒤 배포를 붙잡고 있는 대신, PR 을 보고 있는 동안 백그라운드로 돈다.

배포 경로는 짧아지고 안전망은 남는다.

## 머지 후 해야 할 설정

이 검증이 실제로 게이트가 되려면 브랜치 보호가 필요하다.

**Settings → Branches → main → Require status checks to pass** 에서
`테스트` 체크를 필수로 지정할 것. 지정하지 않으면 빨간 PR 도 머지된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
