### PR TITLE
feat(kafka): notification 에도 DLT 재적재 경로를 연다

### DIFF
--- a/notification/src/main/java/com/comatching/notification/NotificationApplication.java
+++ b/notification/src/main/java/com/comatching/notification/NotificationApplication.java
@@ -11,8 +11,10 @@ import org.springframework.context.annotation.Import;
 
 import com.comatching.common.config.S3Config;
 import com.comatching.common.config.kafka.KafkaConsumerConfig;
+import com.comatching.common.config.kafka.KafkaDltRedriveController;
 import com.comatching.common.config.kafka.KafkaDltTopicConfig;
 import com.comatching.common.config.kafka.KafkaProducerConfig;
+import com.comatching.common.filter.InternalApiAuthenticationFilter;
 
 @SpringBootApplication(
 	exclude = {
@@ -26,7 +28,13 @@ import com.comatching.common.config.kafka.KafkaProducerConfig;
 	// 이 서비스는 발행을 하지 않지만 DLT 발행에는 프로듀서가 필요하다.
 	// 없으면 재시도를 다 쓴 메시지를 옮길 수단이 없어 컨텍스트가 뜨지 않는다.
 	KafkaProducerConfig.class,
-	KafkaDltTopicConfig.class
+	KafkaDltTopicConfig.class,
+	// DLT 재적재 트리거와 그 인증 필터. 이 서비스는 common 을 컴포넌트
+	// 스캔하지 않아 여기 안 적으면 빈이 안 생긴다. 컨트롤러만 넣고 필터를
+	// 빠뜨리면 /api/internal/** 이 무인증으로 열리므로(SecurityConfig 는
+	// 해당 경로를 permitAll 로 두고 필터에 위임) 반드시 둘을 같이 등록한다.
+	KafkaDltRedriveController.class,
+	InternalApiAuthenticationFilter.class
 })
 public class NotificationApplication {
 

--- a/notification/src/main/resources/application-aws.yml
+++ b/notification/src/main/resources/application-aws.yml
@@ -57,3 +57,8 @@ comatching:
     dlt-topics: member-signup,member-withdraw,chat-notification
     # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
     dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}
+
+# /api/internal/** 를 지키는 InternalApiAuthenticationFilter 의 검사 토큰.
+# 비우면 내부 API 전체가 401 로 닫힌다(fail-closed).
+internal:
+  service-token: ${INTERNAL_SERVICE_TOKEN:}

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -55,3 +55,8 @@ comatching:
     dlt-topics: member-signup,member-withdraw,chat-notification
     # DLT 적재를 알릴 웹훅(Discord/Slack 겸용). 비우면 로그만 남는다.
     dlt-alert-webhook-url: ${DLT_ALERT_WEBHOOK_URL:}
+
+# /api/internal/** 를 지키는 InternalApiAuthenticationFilter 의 검사 토큰.
+# 비우면 내부 API 전체가 401 로 닫힌다(fail-closed).
+internal:
+  service-token: ${INTERNAL_SERVICE_TOKEN:}

--- a/notification/src/test/java/com/comatching/notification/NotificationApplicationImportTest.java
+++ b/notification/src/test/java/com/comatching/notification/NotificationApplicationImportTest.java
@@ -1,0 +1,29 @@
+package com.comatching.notification;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+
+import com.comatching.common.config.kafka.KafkaDltRedriveController;
+import com.comatching.common.filter.InternalApiAuthenticationFilter;
+
+/**
+ * DLT 재적재 컨트롤러와 내부 인증 필터가 반드시 함께 등록되는지 검사한다.
+ *
+ * 이 서비스는 common 을 컴포넌트 스캔하지 않고 @Import 로 골라 쓰기 때문에,
+ * 컨트롤러만 넣고 필터를 빠뜨리면 /api/internal/** 이 무인증으로 열린다
+ * (SecurityConfig 는 해당 경로를 permitAll 로 두고 검사를 필터에 위임한다).
+ * 실수로 한쪽만 지우는 회귀를 컴파일 수준이 아니라 테스트로 잡는다.
+ */
+class NotificationApplicationImportTest {
+
+	@Test
+	void dltRedriveControllerMustBeImportedWithInternalAuthFilter() {
+		Import imports = NotificationApplication.class.getAnnotation(Import.class);
+
+		assertThat(imports).isNotNull();
+		assertThat(imports.value())
+			.contains(KafkaDltRedriveController.class, InternalApiAuthenticationFilter.class);
+	}
+}


### PR DESCRIPTION
## 문제

notification 은 common 을 컴포넌트 스캔하지 않고 `@Import` 로 필요한 것만 골라 쓰는 서비스라(DB 자동설정을 꺼둔 설계), #64 의 `KafkaDltRedriveController` 가 다른 소비 서비스에는 자동 등록됐지만 여기서만 빠졌다.

그 결과 이 서비스가 소비하는 `member-signup` · `member-withdraw` · `chat-notification` 의 DLT 는 쌓이기만 하고 되돌릴 수단이 없었다. 특히 `member-withdraw` 재적재는 tombstone TTL(2일, #60) 안에 해야 하는 시한부 작업인데 실행 경로 자체가 막혀 있던 상태다.

## 변경

- `@Import` 에 `KafkaDltRedriveController` + `InternalApiAuthenticationFilter` 를 **세트로** 추가
  - SecurityConfig 가 `/api/internal/**` 를 permitAll 로 두고 검사를 필터에 위임하므로, 컨트롤러만 넣으면 무인증 엔드포인트가 된다
  - 재적재 로직(`KafkaDltRedriveService`)은 이미 import 중인 `KafkaConsumerConfig` 의 빈이라 이 배선만으로 경로가 완성된다
- yml 에 `internal.service-token: ${INTERNAL_SERVICE_TOKEN:}` 매핑 추가 — 다른 서비스와 동일 관례, 값은 compose `env_file` 로 이미 전달됨
- 한쪽만 지우는 회귀를 잡는 테스트 추가 (`NotificationApplicationImportTest`)

## 검증

`:notification:test` 통과 — 신규 1 + 기존 7 (skip 1 은 원래 `@Disabled` 컨텍스트 테스트).

배포 후 재적재 호출:

```
curl -X POST -H "X-Internal-Token: $TOKEN" \
  "http://<notification>/api/internal/kafka/dlt/redrive?topic=member-withdraw"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)