### PR TITLE
fix(matching): 표본 창이 비면 처음부터 다시 훑어 후보를 찾는다

### DIFF
--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
@@ -55,6 +55,15 @@ import java.util.*;
  * 연속한 N 건을 읽는다. '무작위 공간에서의 연속 구간'이므로 실제로는 무작위 표본이다.
  * 인덱스 시크 한 번이라 전체 인원과 무관하게 O(표본 크기) 다.
  * <p>
+ * == 창이 비면 처음부터 다시 훑는다 ==
+ * random_key 는 0~10 억, randomStart 는 0~9 억에서 뽑는다. 조건을 통과한 후보
+ * 전원의 키가 randomStart 보다 작으면 창이 텅 빈다. 후보가 N 명일 때 그 확률이
+ * 0.9^N/(N+1) 이라 N 이 작을수록 급격히 커진다 - 1 명이면 45%, 3 명이면 18%,
+ * 10 명이면 3% 다. 예전에는 이걸 그대로 '후보 없음'으로 돌려줘서, 후보 풀이 작은
+ * 초기 서비스에서는 멀쩡한 상대를 두고도 매칭이 실패했다.
+ * 그래서 첫 조회가 빈손이면 randomStart 를 0 으로 낮춰 한 번 더 조회한다.
+ * 후보가 많을 때는 첫 조회가 거의 항상 성공하므로 추가 비용이 없다.
+ * <p>
  * == 필수 조건을 표본 '안'이 아니라 '밖'에서 거는 이유 ==
  * 거꾸로다 — 필수 조건은 표본을 뽑을 때 함께 적용한다.
  * 뽑고 나서 거르면 5,000 명이 조건 통과분만 남아 수백 명으로 쪼그라든다.
@@ -77,6 +86,18 @@ public class MatchingCandidateRepositoryImpl implements MatchingCandidateReposit
 
     @Override
     public Optional<MatchingCandidate> findBestCandidate(MatchingCandidateSearchCondition condition) {
+        Optional<MatchingCandidate> found = queryBestCandidate(condition);
+
+        // 표본 창(random_key >= randomStart)이 비었다. 조건에 맞는 사람이 정말 없는 건지,
+        // 있는데 전원이 창 앞쪽에 몰린 건지 구분이 안 되므로 0 부터 한 번 더 훑는다.
+        // 이 두 번째 조회는 첫 조회가 빈손일 때만 나가므로 정상 경로의 비용은 그대로다.
+        if (found.isEmpty() && condition.randomStart() != 0) {
+            return queryBestCandidate(condition.withRandomStart(0));
+        }
+        return found;
+    }
+
+    private Optional<MatchingCandidate> queryBestCandidate(MatchingCandidateSearchCondition condition) {
 
         Map<String, Object> params = new LinkedHashMap<>();
 

--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateSearchCondition.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateSearchCondition.java
@@ -29,4 +29,12 @@ public record MatchingCandidateSearchCondition(
         AgeOption scoreAgeOption,
         ContactFrequency scoreContactFrequency
 ) {
+
+    /** randomStart 만 바꾼 사본. 표본 창이 비었을 때 처음부터 다시 훑기 위해 쓴다. */
+    public MatchingCandidateSearchCondition withRandomStart(int newRandomStart) {
+        return new MatchingCandidateSearchCondition(
+                newRandomStart, sampleSize, targetGender, excludeMajor, excludeMemberIds,
+                minAge, maxAge, requiredMbtiTraits, requiredContactFrequency, requiredHobbyCategory,
+                myAge, scoreMbtiTraits, scoreHobbyCategory, scoreAgeOption, scoreContactFrequency);
+    }
 }

--- a/matching-service/src/test/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryIT.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryIT.java
@@ -289,7 +289,7 @@ class MatchingCandidateRepositoryIT extends MySqlContainerSupport {
 		}
 
 		@Test
-		@DisplayName("randomStart 보다 앞선 키를 가진 후보는 표본에서 빠진다")
+		@DisplayName("창에 후보가 있으면 randomStart 보다 앞선 키는 표본에서 빠진다")
 		void randomStartSkipsEarlierKeys() {
 			save(1L, "XXXX", 99, ContactFrequency.RARE, List.of());
 			save(2L, "XXXX", 99, ContactFrequency.RARE, List.of());
@@ -300,6 +300,46 @@ class MatchingCandidateRepositoryIT extends MySqlContainerSupport {
 				.get()
 				.extracting(MatchingCandidate::getMemberId)
 				.isEqualTo(3L);
+		}
+
+		@Test
+		@DisplayName("창이 비면 처음부터 다시 훑어 후보를 찾아낸다")
+		void wrapsAroundWhenWindowIsEmpty() {
+			// random_key 는 삽입할 때 0~10억 중 하나로 정해지고, randomStart 는 요청마다
+			// 0~9억 중 하나로 새로 뽑힌다. 후보 전원의 키가 randomStart 보다 작으면
+			// 창이 비는데, 예전에는 그대로 '후보 없음'이 되어 요청이 실패했다.
+			// 후보 수가 적을수록 자주 걸린다 - 조건 통과자가 1명이면 45%, 3명이면 18%다.
+			save(1L, "XXXX", 99, ContactFrequency.RARE, List.of());
+			save(2L, "XXXX", 99, ContactFrequency.RARE, List.of());
+			fixRandomKeysByMemberId();   // random_key = 1, 2
+
+			assertThat(findBest(base().randomStart(10).build())).isPresent();
+		}
+
+		@Test
+		@DisplayName("다시 훑을 때도 필수 조건은 그대로 지킨다")
+		void wrapAroundStillRespectsFilters() {
+			save(1L, "XXXX", 99, ContactFrequency.RARE, List.of());
+			save(2L, "XXXX", 99, ContactFrequency.FREQUENT, List.of());
+			fixRandomKeysByMemberId();
+
+			assertThat(findBest(base()
+				.randomStart(10)
+				.requiredContactFrequency(ContactFrequency.FREQUENT)
+				.build()))
+				.get()
+				.extracting(MatchingCandidate::getMemberId)
+				.isEqualTo(2L);
+		}
+
+		@Test
+		@DisplayName("다시 훑어도 조건에 맞는 후보가 없으면 빈 결과를 준다")
+		void wrapAroundStillEmptyWhenNothingMatches() {
+			// 재조회가 조건을 무시하고 아무나 집어오지 않는지 본다.
+			save(1L, "XXXX", 99, ContactFrequency.RARE, List.of());
+			fixRandomKeysByMemberId();
+
+			assertThat(findBest(base().randomStart(10).minAge(200).build())).isEmpty();
 		}
 
 		@Test


### PR DESCRIPTION
## 증상

실제 가입 후 매칭을 요청했더니 조건에 맞는 상대가 있는데도 `MATCH-001 매칭 후보가 없습니다` 가 떴다.

## 원인

후보 표본은 `(gender, is_matchable, random_key)` 인덱스에서 `random_key >= randomStart` 지점으로 점프해 뽑는다.

- `random_key` : 후보를 넣을 때 `0 ~ 10억` 중 하나로 정해진다
- `randomStart` : 매칭을 요청할 때마다 `0 ~ 9억` 중 하나로 새로 뽑힌다

조건을 통과한 후보 **전원**의 키가 `randomStart` 보다 작으면 창이 텅 빈다. 그런데 이걸 그대로 '후보 없음'으로 돌려주고 있었다. 창을 다시 훑는 경로가 없었다.

창이 빌 확률은 조건 통과 후보가 N 명일 때 `0.9^N/(N+1)` 이다. 해석적 계산과 20만 회 시뮬레이션이 일치한다.

| 조건 통과 후보 N | 창이 빌 확률 |
|---|---|
| 1 | **45.0%** |
| 3 | 18.2% |
| 10 | 3.2% |
| 50 | 0.01% |

후보가 많으면 사실상 0 이라, 5만 명 규모를 가정하고 만든 원래 설계에서는 드러나지 않았다. 문제는 **N 이 전체 가입자 수가 아니라 필터를 전부 통과한 인원**이라는 점이다. 이성 50명(총 가입자 100명) 기준으로 옵션별 실패율을 시뮬레이션하면:

| 사용자가 건 조건 | 조건 통과 후보 N | 현재 실패율 | 이 PR 적용 후 | 버그 기여분 |
|---|---|---|---|---|
| 옵션 없음 | 47.5 | 0.0% | 0.0% | — |
| 취미 중요 | 23.8 | 0.4% | 0.0% | 0.4%p |
| 연락빈도 중요 | 15.8 | 1.3% | 0.0% | 1.3%p |
| 동갑 중요 | 8.3 | 8.0% | 0.9% | 7.2%p |
| MBTI 중요(4글자) | 3.0 | **25.4%** | 4.6% | **20.8%p** |
| MBTI+학과제외+나이제한 | 1.3 | **52.4%** | 28.7% | 23.7%p |

MBTI 를 걸면 4번에 1번 실패하고, 그 실패의 **82%가 조건에 맞는 상대가 실제로 있는데도 못 찾은 경우**다. 아이템까지 써서 옵션을 건 사용자가 가장 자주 실패한다.

풀이 커지면 완화되지만(이성 250명 이상이면 거의 안 보인다), 옵션을 빡세게 건 사용자에게는 계속 남는다. 그리고 가장 심한 구간이 정확히 초기 사용자 확보 구간이다.

## 수정

첫 조회가 빈손이고 `randomStart != 0` 이면, `randomStart` 를 0 으로 낮춰 한 번 더 조회한다.

- **SQL 은 건드리지 않았다.** 기존 쿼리 본문을 `queryBestCandidate` 로 분리만 하고 호출부에 재조회를 얹었다
- 인덱스 시크 기반 `O(표본 크기)` 특성 그대로다. `ORDER BY (random_key < start), random_key` 같은 순환 정렬은 `Using filesort` 를 되살려 성능 개선을 되돌리므로 쓰지 않았다
- **필수 조건은 재조회에서도 그대로 유지된다.** 조건에 맞는 사람이 정말 없으면 여전히 빈 결과가 나간다
- 두 번째 조회는 첫 조회가 실패할 때만 나가고, 그 상황은 애초에 조건 통과자가 적어 쿼리가 싸다. **정상 경로의 비용은 달라지지 않는다**

## 테스트

`MatchingCandidateRepositoryIT` 에 3개 추가. Testcontainers 실 MySQL 8.0 위에서 돈다.

- `창이 비면 처음부터 다시 훑어 후보를 찾아낸다` — 수정 전 실패, 수정 후 통과
- `다시 훑을 때도 필수 조건은 그대로 지킨다` — 수정 전 실패, 수정 후 통과
- `다시 훑어도 조건에 맞는 후보가 없으면 빈 결과를 준다` — 재조회가 조건을 무시하고 아무나 집어오지 않는지 보는 가드

기존 `randomStartSkipsEarlierKeys` 는 그대로 통과한다(창에 후보가 있으면 동작이 이전과 같다). 전제가 좁아져서 DisplayName 만 정확하게 고쳤다.

`./gradlew :matching-service:test` → **84개 통과, 실패 0** (스킵 2개는 기존 `@Disabled`).

## 이 PR 에 넣지 않은 것

`NO_MATCHING_CANDIDATE` 의 HTTP 상태가 `500 INTERNAL_SERVER_ERROR` 다. 조건에 맞는 상대가 없는 건 서버 오류가 아니라 정상적인 결과라 4xx 가 맞고, 지금은 모니터링 알람도 같이 울린다. 다만 프론트 에러 핸들링에 영향이 가는 계약 변경이라 이 PR 에 섞지 않았다. 별도로 논의하면 좋겠다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
