### PR TITLE
fix(chat): 채팅 신뢰성 4건 - 에러 전달, 자동 읽음, 방 지연 생성, 차단 활성화

### DIFF
--- a/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatRoomRepositoryCustom.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatRoomRepositoryCustom.java
@@ -7,4 +7,6 @@ public interface ChatRoomRepositoryCustom {
 	boolean touchLastReadAt(String roomId, Long memberId, LocalDateTime readAt);
 
 	boolean updateLastMessageIfLatest(String roomId, String previewContent, LocalDateTime sentAt);
+
+	boolean activateRoom(String roomId);
 }

--- a/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatRoomRepositoryImpl.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/repository/ChatRoomRepositoryImpl.java
@@ -62,4 +62,18 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 		UpdateResult result = mongoTemplate.updateFirst(query, update, ChatRoom.class);
 		return result.getMatchedCount() > 0;
 	}
+
+	// 활성화만 따로 떼어낸 이유: 요약 갱신(updateLastMessageIfLatest)이 활성화를
+	// 겸하는데, 차단된 상대에게 보낸 메시지는 요약을 갱신하지 않아 방이 영구
+	// WAITING 으로 남았다. 차단이 풀린 뒤에도 target 에게 방이 보이려면
+	// 활성화는 요약과 독립적으로 일어나야 한다.
+	@Override
+	public boolean activateRoom(String roomId) {
+		UpdateResult result = mongoTemplate.updateFirst(
+			Query.query(Criteria.where("_id").is(roomId).and("status").is(ChatRoomStatus.WAITING)),
+			new Update().set("status", ChatRoomStatus.ACTIVE),
+			ChatRoom.class
+		);
+		return result.getModifiedCount() > 0;
+	}
 }

--- a/chat-service/src/main/java/com/comatching/chat/domain/service/chat/ChatServiceImpl.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/service/chat/ChatServiceImpl.java
@@ -92,6 +92,11 @@ public class ChatServiceImpl implements ChatService {
 		if (!isBlockedByReceiver) {
 			updateChatRoomInfo(chatRoom, request, savedMessage.getId(), sentAt);
 			publishNotificationEvent(chatRoom, request, sentAt);
+		} else {
+			// 요약·알림은 차단 수신자에게 새 메시지 힌트를 주지 않으려 스킵하지만,
+			// 활성화까지 스킵하면 방이 영구 WAITING 으로 남아 차단을 풀어도
+			// target 목록에 방이 나타나지 않는다.
+			chatRoomRepository.activateRoom(chatRoom.getId());
 		}
 
 		return ChatMessageResponse.from(savedMessage, 1);

--- a/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomService.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.comatching.chat.domain.service.chatroom;
 import java.util.List;
 
 import com.comatching.chat.domain.dto.ChatRoomResponse;
+import com.comatching.common.dto.chat.ChatRoomEnsureRequest;
 import com.comatching.common.dto.chat.ChatRoomReferenceResponse;
 import com.comatching.common.dto.event.matching.MatchingSuccessEvent;
 
@@ -17,4 +18,6 @@ public interface ChatRoomService {
 	void validateRoomMember(String roomId, Long memberId);
 
 	List<ChatRoomReferenceResponse> getChatRoomReferencesByMatchingIds(List<Long> matchingIds);
+
+	List<ChatRoomReferenceResponse> ensureChatRooms(List<ChatRoomEnsureRequest> requests);
 }

--- a/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImpl.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,7 @@ import com.comatching.chat.domain.repository.UnreadCountCondition;
 import com.comatching.chat.domain.service.block.BlockService;
 import com.comatching.chat.global.exception.ChatErrorCode;
 import com.comatching.chat.infra.client.MemberClient;
+import com.comatching.common.dto.chat.ChatRoomEnsureRequest;
 import com.comatching.common.dto.chat.ChatRoomReferenceResponse;
 import com.comatching.common.dto.event.matching.MatchingSuccessEvent;
 import com.comatching.common.dto.member.ProfileResponse;
@@ -134,6 +136,57 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		return chatRoomRepository.findByMatchingIdIn(matchingIds).stream()
 			.map(room -> new ChatRoomReferenceResponse(room.getMatchingId(), room.getId()))
 			.toList();
+	}
+
+	/**
+	 * 매칭에 대응하는 방이 없으면 그 자리에서 만든다.
+	 *
+	 * 방 생성은 원래 매칭 성공 Kafka 이벤트로만 일어났는데, 발행이 유실되면
+	 * 그 매칭은 영구히 방이 없었다. 매칭 이력 조회가 이 경로를 타므로
+	 * 유실분은 사용자가 이력을 여는 순간 자동으로 복구된다.
+	 *
+	 * Kafka 컨슈머와 동시에 만들 수 있으나 matchingId 의 unique 인덱스가 중복을
+	 * 막아 주고, 충돌하면 먼저 만들어진 방을 다시 읽어 돌려준다.
+	 */
+	@Override
+	public List<ChatRoomReferenceResponse> ensureChatRooms(List<ChatRoomEnsureRequest> requests) {
+		if (requests == null || requests.isEmpty()) {
+			return List.of();
+		}
+
+		List<Long> matchingIds = requests.stream()
+			.map(ChatRoomEnsureRequest::matchingId)
+			.toList();
+
+		Map<Long, ChatRoom> roomsByMatchingId = chatRoomRepository.findByMatchingIdIn(matchingIds).stream()
+			.collect(Collectors.toMap(ChatRoom::getMatchingId, Function.identity(), (left, right) -> left));
+
+		return requests.stream()
+			.map(request -> {
+				ChatRoom room = roomsByMatchingId.get(request.matchingId());
+				if (room == null) {
+					room = createMissingRoom(request);
+				}
+				return new ChatRoomReferenceResponse(request.matchingId(), room.getId());
+			})
+			.toList();
+	}
+
+	private ChatRoom createMissingRoom(ChatRoomEnsureRequest request) {
+		ChatRoom newRoom = ChatRoom.builder()
+			.matchingId(request.matchingId())
+			.initiatorUserId(request.initiatorUserId())
+			.targetUserId(request.targetUserId())
+			.build();
+
+		try {
+			ChatRoom saved = chatRoomRepository.save(newRoom);
+			log.info("Lazily created chat room. matchingId={}, roomId={}", request.matchingId(), saved.getId());
+			return saved;
+		} catch (DuplicateKeyException e) {
+			return chatRoomRepository.findByMatchingId(request.matchingId())
+				.orElseThrow(() -> e);
+		}
 	}
 
 	private Map<String, Long> getUnreadCountsByRoom(List<ChatRoom> rooms, Long memberId) {

--- a/chat-service/src/main/java/com/comatching/chat/domain/service/presence/ChatRoomPresenceTracker.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/service/presence/ChatRoomPresenceTracker.java
@@ -1,0 +1,85 @@
+package com.comatching.chat.domain.service.presence;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+/**
+ * 이 인스턴스에 붙어 있는 WebSocket 세션이 어느 채팅방 토픽을 구독 중인지 기억한다.
+ *
+ * 읽음 처리는 원래 클라이언트가 방 입장 때 보내는 READ 한 번에만 의존했다.
+ * 방을 켜둔 채로 받은 메시지는 아무도 읽음 처리하지 않아 "1" 이 영원히 남았다.
+ * 이 추적기가 있으면 메시지를 뿌리는 시점에 수신자가 그 방을 보고 있는지 판단해
+ * 서버가 대신 읽음 처리할 수 있다.
+ *
+ * 인스턴스별 메모리라는 점이 핵심이다. 메시지는 Redis 를 거쳐 모든 인스턴스에
+ * 도착하므로, 각 인스턴스는 자기에게 붙은 세션만 책임지면 수평 확장에도 맞다.
+ */
+@Component
+public class ChatRoomPresenceTracker {
+
+	private static final String CHAT_ROOM_TOPIC_PREFIX = "/topic/chat.room.";
+
+	private record RoomSubscription(String roomId, Long memberId) {
+	}
+
+	// sessionId -> (subscriptionId -> 구독 정보). 구독 해지 이벤트에는 destination 이
+	// 없고 subscriptionId 만 오므로 이 형태로 들고 있어야 지울 수 있다.
+	private final Map<String, Map<String, RoomSubscription>> subscriptionsBySession = new ConcurrentHashMap<>();
+
+	@EventListener
+	public void onSubscribe(SessionSubscribeEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+		String destination = accessor.getDestination();
+		if (destination == null || !destination.startsWith(CHAT_ROOM_TOPIC_PREFIX)) {
+			return;
+		}
+
+		Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+		Object memberId = (sessionAttributes == null) ? null : sessionAttributes.get("memberId");
+		String sessionId = accessor.getSessionId();
+		String subscriptionId = accessor.getSubscriptionId();
+		if (!(memberId instanceof Long) || sessionId == null || subscriptionId == null) {
+			return;
+		}
+
+		String roomId = destination.substring(CHAT_ROOM_TOPIC_PREFIX.length());
+		subscriptionsBySession
+			.computeIfAbsent(sessionId, key -> new ConcurrentHashMap<>())
+			.put(subscriptionId, new RoomSubscription(roomId, (Long)memberId));
+	}
+
+	@EventListener
+	public void onUnsubscribe(SessionUnsubscribeEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+		String subscriptionId = accessor.getSubscriptionId();
+		if (sessionId == null || subscriptionId == null) {
+			return;
+		}
+
+		Map<String, RoomSubscription> sessionSubscriptions = subscriptionsBySession.get(sessionId);
+		if (sessionSubscriptions != null) {
+			sessionSubscriptions.remove(subscriptionId);
+		}
+	}
+
+	@EventListener
+	public void onDisconnect(SessionDisconnectEvent event) {
+		subscriptionsBySession.remove(event.getSessionId());
+	}
+
+	public boolean isViewing(String roomId, Long memberId) {
+		return subscriptionsBySession.values().stream()
+			.flatMap(sessionSubscriptions -> sessionSubscriptions.values().stream())
+			.anyMatch(subscription ->
+				subscription.roomId().equals(roomId) && subscription.memberId().equals(memberId));
+	}
+}

--- a/chat-service/src/main/java/com/comatching/chat/domain/service/redis/RedisSubscriber.java
+++ b/chat-service/src/main/java/com/comatching/chat/domain/service/redis/RedisSubscriber.java
@@ -3,13 +3,17 @@ package com.comatching.chat.domain.service.redis;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 import com.comatching.chat.domain.dto.ChatMessageResponse;
 import com.comatching.chat.domain.entity.ChatRoom;
 import com.comatching.chat.domain.repository.ChatRoomRepository;
+import com.comatching.chat.domain.enums.MessageType;
 import com.comatching.chat.domain.service.block.BlockService;
+import com.comatching.chat.domain.service.chat.ChatService;
+import com.comatching.chat.domain.service.presence.ChatRoomPresenceTracker;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +29,9 @@ public class RedisSubscriber implements MessageListener {
 	private final SimpMessageSendingOperations messagingTemplate;
 	private final ChatRoomRepository chatRoomRepository;
 	private final BlockService blockService;
+	private final ChatRoomPresenceTracker presenceTracker;
+	private final ChatService chatService;
+	private final RedisPublisher redisPublisher;
 
 	@Override
 	public void onMessage(Message message, byte[] pattern) {
@@ -49,8 +56,37 @@ public class RedisSubscriber implements MessageListener {
 
 			messagingTemplate.convertAndSend("/topic/chat.room." + roomMessage.roomId(), roomMessage);
 
+			autoReadIfReceiverIsViewing(roomMessage, receiverId);
+
 		} catch (Exception e) {
 			log.error("Redis 메시지 전달 오류: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * 수신자가 지금 이 인스턴스에서 그 방을 보고 있으면 서버가 대신 읽음 처리한다.
+	 *
+	 * 읽음 갱신이 클라이언트의 READ 전송에만 의존하면, 방을 켜둔 채 받은 메시지는
+	 * 수신자가 방을 나갔다 다시 들어올 때까지 "안 읽음" 으로 남는다.
+	 *
+	 * READ 는 sender 의 인스턴스가 아니라 여기(수신자 세션을 쥔 인스턴스)서 Redis 로
+	 * 발행한다. 그래야 발신자가 다른 인스턴스에 붙어 있어도 읽음 전파를 받는다.
+	 * READ 메시지 자체에는 반응하지 않으므로 발행이 꼬리를 물지 않는다.
+	 */
+	private void autoReadIfReceiverIsViewing(ChatMessageResponse roomMessage, Long receiverId) {
+		if (roomMessage.type() == MessageType.READ) {
+			return;
+		}
+		if (!presenceTracker.isViewing(roomMessage.roomId(), receiverId)) {
+			return;
+		}
+
+		try {
+			ChatMessageResponse readResponse = chatService.markAsRead(roomMessage.roomId(), receiverId);
+			redisPublisher.publish(new ChannelTopic("chatroom"), readResponse);
+		} catch (Exception e) {
+			// 자동 읽음은 편의 기능이다. 실패해도 메시지 전달을 되돌릴 이유는 없다.
+			log.warn("자동 읽음 처리 실패 - roomId: {}, receiverId: {}", roomMessage.roomId(), receiverId, e);
 		}
 	}
 

--- a/chat-service/src/main/java/com/comatching/chat/global/exception/ChatErrorHandler.java
+++ b/chat-service/src/main/java/com/comatching/chat/global/exception/ChatErrorHandler.java
@@ -4,6 +4,9 @@ import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
+import com.comatching.common.dto.response.ApiResponse;
+import com.comatching.common.exception.BusinessException;
+
 @ControllerAdvice
 public class ChatErrorHandler {
 
@@ -11,5 +14,14 @@ public class ChatErrorHandler {
 	@SendToUser("/queue/errors")
 	public String handleException(ChatException e) {
 		return "ERROR: " + e.getMessage();
+	}
+
+	// 채팅 코드가 실제로 던지는 예외는 BusinessException 이다. 위의 ChatException
+	// 핸들러는 던지는 곳이 없어서 한 번도 발화하지 않았고, 그동안 방이 없거나
+	// 권한이 없어 실패한 전송이 클라이언트에 아무 신호도 남기지 못했다.
+	@MessageExceptionHandler(BusinessException.class)
+	@SendToUser("/queue/errors")
+	public ApiResponse<Void> handleBusinessException(BusinessException e) {
+		return ApiResponse.errorResponse(e.getErrorCode());
 	}
 }

--- a/chat-service/src/main/java/com/comatching/chat/infra/controller/ChatController.java
+++ b/chat-service/src/main/java/com/comatching/chat/infra/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.comatching.chat.infra.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.listener.ChannelTopic;
@@ -59,13 +60,19 @@ public class ChatController {
 		@Payload ChatMessageRequest request,
 		SimpMessageHeaderAccessor headerAccessor) {
 
-		Long memberId = (Long)headerAccessor.getSessionAttributes().get("memberId");
-		String nickname = headerAccessor.getSessionAttributes().get("nickname").toString();
+		Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+		Long memberId = (sessionAttributes == null) ? null : (Long)sessionAttributes.get("memberId");
 
 		if (memberId == null) {
 			log.error("인증되지 않은 사용자의 접근입니다.");
 			return;
 		}
+
+		// 닉네임은 알림 미리보기에만 쓴다. 프로필 완성 전에 발급된 토큰에는
+		// nickname 클레임이 없어서 게이트웨이가 헤더를 안 보내는데, 예전에는
+		// 여기서 바로 NPE 가 나 전송 자체가 죽었다.
+		Object rawNickname = sessionAttributes.get("nickname");
+		String nickname = (rawNickname == null) ? "" : rawNickname.toString();
 
 		ChatMessageRequest securedRequest = new ChatMessageRequest(
 			request.roomId(),
@@ -95,4 +102,5 @@ public class ChatController {
 		List<ChatMessageResponse> messages = chatService.getChatHistory(roomId, memberInfo.memberId(), pageable);
 		return ResponseEntity.ok(ApiResponse.ok(messages));
 	}
+
 }

--- a/chat-service/src/main/java/com/comatching/chat/infra/controller/ChatController.java
+++ b/chat-service/src/main/java/com/comatching/chat/infra/controller/ChatController.java
@@ -103,4 +103,16 @@ public class ChatController {
 		return ResponseEntity.ok(ApiResponse.ok(messages));
 	}
 
+	// 읽음 처리의 REST 경로. WebSocket 이 아직 안 붙었거나 끊긴 채로 방을 열면
+	// 히스토리는 HTTP 로 읽히는데 읽음은 기록될 길이 없었다. READ 는 WS 때와
+	// 같이 Redis 로 발행해 상대 화면의 "1" 도 같이 지운다.
+	@PostMapping("/api/chat/rooms/{roomId}/read")
+	public ResponseEntity<ApiResponse<Void>> markAsRead(
+		@PathVariable String roomId,
+		@CurrentMember MemberInfo memberInfo) {
+
+		ChatMessageResponse readResponse = chatService.markAsRead(roomId, memberInfo.memberId());
+		redisPublisher.publish(topic, readResponse);
+		return ResponseEntity.ok(ApiResponse.ok());
+	}
 }

--- a/chat-service/src/main/java/com/comatching/chat/infra/controller/InternalChatRoomController.java
+++ b/chat-service/src/main/java/com/comatching/chat/infra/controller/InternalChatRoomController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.comatching.chat.domain.service.chatroom.ChatRoomService;
+import com.comatching.common.dto.chat.ChatRoomEnsureRequest;
 import com.comatching.common.dto.chat.ChatRoomReferenceResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -22,5 +23,10 @@ public class InternalChatRoomController {
 	@PostMapping("/references")
 	public List<ChatRoomReferenceResponse> getChatRoomReferences(@RequestBody List<Long> matchingIds) {
 		return chatRoomService.getChatRoomReferencesByMatchingIds(matchingIds);
+	}
+
+	@PostMapping("/ensure")
+	public List<ChatRoomReferenceResponse> ensureChatRooms(@RequestBody List<ChatRoomEnsureRequest> requests) {
+		return chatRoomService.ensureChatRooms(requests);
 	}
 }

--- a/chat-service/src/test/java/com/comatching/chat/domain/repository/ChatRoomRepositoryImplTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/domain/repository/ChatRoomRepositoryImplTest.java
@@ -115,4 +115,27 @@ class ChatRoomRepositoryImplTest {
 		assertThat(update.get("$set", Document.class)).containsEntry("status", ChatRoomStatus.ACTIVE);
 		assertThat(update.get("$max", Document.class)).containsEntry("updatedAt", sentAt);
 	}
+
+	@Test
+	@DisplayName("activateRoom은 WAITING인 방만 ACTIVE로 바꾼다")
+	void activateRoom_flipsOnlyWaitingRoom() {
+		// given
+		given(mongoTemplate.updateFirst(any(Query.class), any(Update.class), eq(ChatRoom.class)))
+			.willReturn(UpdateResult.acknowledged(1, 1L, null));
+
+		// when
+		boolean result = repository.activateRoom(ROOM_ID);
+
+		// then
+		assertThat(result).isTrue();
+		ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+		ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+		then(mongoTemplate).should().updateFirst(queryCaptor.capture(), updateCaptor.capture(), eq(ChatRoom.class));
+
+		Document query = queryCaptor.getValue().getQueryObject();
+		Document update = updateCaptor.getValue().getUpdateObject();
+		assertThat(query).containsEntry("_id", ROOM_ID);
+		assertThat(query).containsEntry("status", ChatRoomStatus.WAITING);
+		assertThat(update.get("$set", Document.class)).containsEntry("status", ChatRoomStatus.ACTIVE);
+	}
 }

--- a/chat-service/src/test/java/com/comatching/chat/domain/service/chat/ChatServiceImplTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/domain/service/chat/ChatServiceImplTest.java
@@ -153,6 +153,28 @@ class ChatServiceImplTest {
 	}
 
 	@Test
+	@DisplayName("차단된 상대에게 보낸 첫 메시지도 방은 활성화한다 - 차단 해제 후 방이 보여야 한다")
+	void processMessage_activatesRoomEvenWhenSenderIsBlockedByReceiver() {
+		// given - 요약 갱신(updateLastMessageIfLatest)이 활성화를 겸하는데 차단 시
+		// 그 경로가 통째로 스킵되어 방이 영구 WAITING 으로 남는 구멍이 있었다
+		LocalDateTime createdAt = LocalDateTime.of(2026, 5, 16, 10, 6);
+		ChatRoom room = chatRoom(ROOM_ID, INITIATOR_ID, TARGET_ID);
+		ChatMessage savedMessage = savedMessage("message-3", INITIATOR_ID, "blocked", MessageType.TALK, createdAt);
+
+		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		given(blockService.isBlocked(TARGET_ID, INITIATOR_ID)).willReturn(true);
+		given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+
+		// when
+		chatService.processMessage(talkRequest(INITIATOR_ID, "sender", "blocked"));
+
+		// then - 활성화만 하고 요약과 알림은 여전히 스킵한다
+		then(chatRoomRepository).should().activateRoom(ROOM_ID);
+		then(chatRoomRepository).should(never()).updateLastMessageIfLatest(anyString(), anyString(), any());
+		then(chatEventProducer).shouldHaveNoInteractions();
+	}
+
+	@Test
 	@DisplayName("READ 메시지는 메시지를 저장하지 않고 발신자의 readAt만 atomic update 한다")
 	void processMessage_readOnlyTouchesLastReadAt() {
 		// given

--- a/chat-service/src/test/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImplTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/domain/service/chatroom/ChatRoomServiceImplTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -29,6 +30,8 @@ import com.comatching.chat.domain.repository.UnreadCountCondition;
 import com.comatching.chat.domain.service.block.BlockService;
 import com.comatching.chat.global.exception.ChatErrorCode;
 import com.comatching.chat.infra.client.MemberClient;
+import com.comatching.common.dto.chat.ChatRoomEnsureRequest;
+import com.comatching.common.dto.chat.ChatRoomReferenceResponse;
 import com.comatching.common.dto.member.ProfileResponse;
 import com.comatching.common.exception.BusinessException;
 import com.comatching.common.exception.code.GeneralErrorCode;
@@ -301,6 +304,74 @@ class ChatRoomServiceImplTest {
 				tuple(100L, "room-100"),
 				tuple(101L, "room-101")
 			);
+	}
+
+	@Test
+	@DisplayName("ensure는 방이 없는 매칭만 그 자리에서 만들고 전체 참조를 돌려준다")
+	void ensureChatRooms_createsMissingRoomsAndReturnsAllReferences() {
+		// given - 100번 매칭은 방이 있고 101번은 Kafka 유실 등으로 방이 없다
+		ChatRoom existingRoom = chatRoom("room-100", 100L, MEMBER_ID, OTHER_MEMBER_ID, LocalDateTime.now());
+		given(chatRoomRepository.findByMatchingIdIn(List.of(100L, 101L)))
+			.willReturn(List.of(existingRoom));
+		given(chatRoomRepository.save(any(ChatRoom.class))).willAnswer(invocation -> {
+			ChatRoom saved = invocation.getArgument(0);
+			ReflectionTestUtils.setField(saved, "id", "room-101");
+			return saved;
+		});
+
+		List<ChatRoomEnsureRequest> requests = List.of(
+			new ChatRoomEnsureRequest(100L, MEMBER_ID, OTHER_MEMBER_ID),
+			new ChatRoomEnsureRequest(101L, MEMBER_ID, SECOND_OTHER_MEMBER_ID)
+		);
+
+		// when
+		List<ChatRoomReferenceResponse> result = chatRoomService.ensureChatRooms(requests);
+
+		// then
+		assertThat(result).extracting("matchingId", "chatRoomId")
+			.containsExactlyInAnyOrder(
+				tuple(100L, "room-100"),
+				tuple(101L, "room-101")
+			);
+		then(chatRoomRepository).should().save(argThat(room ->
+			room.getMatchingId().equals(101L)
+				&& room.getInitiatorUserId().equals(MEMBER_ID)
+				&& room.getTargetUserId().equals(SECOND_OTHER_MEMBER_ID)));
+	}
+
+	@Test
+	@DisplayName("ensure는 방이 전부 있으면 아무것도 만들지 않는다")
+	void ensureChatRooms_createsNothingWhenAllRoomsExist() {
+		// given
+		ChatRoom existingRoom = chatRoom("room-100", 100L, MEMBER_ID, OTHER_MEMBER_ID, LocalDateTime.now());
+		given(chatRoomRepository.findByMatchingIdIn(List.of(100L)))
+			.willReturn(List.of(existingRoom));
+
+		// when
+		List<ChatRoomReferenceResponse> result =
+			chatRoomService.ensureChatRooms(List.of(new ChatRoomEnsureRequest(100L, MEMBER_ID, OTHER_MEMBER_ID)));
+
+		// then
+		assertThat(result).extracting("chatRoomId").containsExactly("room-100");
+		then(chatRoomRepository).should(never()).save(any(ChatRoom.class));
+	}
+
+	@Test
+	@DisplayName("ensure는 동시 생성 충돌이 나면 이미 만들어진 방을 다시 읽어 돌려준다")
+	void ensureChatRooms_recoversFromDuplicateKeyRace() {
+		// given - findByMatchingIdIn 과 save 사이에 Kafka 컨슈머가 먼저 방을 만든 경우
+		given(chatRoomRepository.findByMatchingIdIn(List.of(100L))).willReturn(List.of());
+		given(chatRoomRepository.save(any(ChatRoom.class)))
+			.willThrow(new DuplicateKeyException("matchingId dup"));
+		ChatRoom concurrentlyCreated = chatRoom("room-100", 100L, MEMBER_ID, OTHER_MEMBER_ID, LocalDateTime.now());
+		given(chatRoomRepository.findByMatchingId(100L)).willReturn(Optional.of(concurrentlyCreated));
+
+		// when
+		List<ChatRoomReferenceResponse> result =
+			chatRoomService.ensureChatRooms(List.of(new ChatRoomEnsureRequest(100L, MEMBER_ID, OTHER_MEMBER_ID)));
+
+		// then
+		assertThat(result).extracting("chatRoomId").containsExactly("room-100");
 	}
 
 	private ChatRoom chatRoom(String id, Long matchingId, Long initiatorId, Long targetId, LocalDateTime readAt) {

--- a/chat-service/src/test/java/com/comatching/chat/domain/service/presence/ChatRoomPresenceTrackerTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/domain/service/presence/ChatRoomPresenceTrackerTest.java
@@ -1,0 +1,122 @@
+package com.comatching.chat.domain.service.presence;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+class ChatRoomPresenceTrackerTest {
+
+	private static final String ROOM_ID = "room-1";
+	private static final Long MEMBER_ID = 1L;
+
+	private ChatRoomPresenceTracker tracker;
+
+	@BeforeEach
+	void setUp() {
+		tracker = new ChatRoomPresenceTracker();
+	}
+
+	@Test
+	@DisplayName("채팅방 토픽을 구독하면 그 방을 보고 있는 것으로 기록한다")
+	void subscribe_marksMemberAsViewing() {
+		tracker.onSubscribe(subscribeEvent("session-1", "sub-1", "/topic/chat.room." + ROOM_ID, MEMBER_ID));
+
+		assertThat(tracker.isViewing(ROOM_ID, MEMBER_ID)).isTrue();
+	}
+
+	@Test
+	@DisplayName("구독한 적 없으면 보고 있지 않다")
+	void isViewing_falseByDefault() {
+		assertThat(tracker.isViewing(ROOM_ID, MEMBER_ID)).isFalse();
+	}
+
+	@Test
+	@DisplayName("채팅방 토픽이 아닌 구독은 무시한다")
+	void subscribe_ignoresNonChatRoomDestinations() {
+		tracker.onSubscribe(subscribeEvent("session-1", "sub-1", "/user/queue/errors", MEMBER_ID));
+
+		assertThat(tracker.isViewing(ROOM_ID, MEMBER_ID)).isFalse();
+	}
+
+	@Test
+	@DisplayName("구독을 해지하면 더 이상 보고 있지 않다")
+	void unsubscribe_removesViewing() {
+		tracker.onSubscribe(subscribeEvent("session-1", "sub-1", "/topic/chat.room." + ROOM_ID, MEMBER_ID));
+
+		tracker.onUnsubscribe(unsubscribeEvent("session-1", "sub-1"));
+
+		assertThat(tracker.isViewing(ROOM_ID, MEMBER_ID)).isFalse();
+	}
+
+	@Test
+	@DisplayName("연결이 끊기면 그 세션의 모든 구독이 사라진다")
+	void disconnect_removesAllSubscriptionsOfSession() {
+		tracker.onSubscribe(subscribeEvent("session-1", "sub-1", "/topic/chat.room." + ROOM_ID, MEMBER_ID));
+		tracker.onSubscribe(subscribeEvent("session-1", "sub-2", "/topic/chat.room.room-2", MEMBER_ID));
+
+		tracker.onDisconnect(disconnectEvent("session-1"));
+
+		assertThat(tracker.isViewing(ROOM_ID, MEMBER_ID)).isFalse();
+		assertThat(tracker.isViewing("room-2", MEMBER_ID)).isFalse();
+	}
+
+	@Test
+	@DisplayName("같은 방을 두 세션으로 보다가 한 세션만 끊기면 여전히 보고 있다")
+	void disconnect_keepsViewingWhileAnotherSessionRemains() {
+		tracker.onSubscribe(subscribeEvent("session-1", "sub-1", "/topic/chat.room." + ROOM_ID, MEMBER_ID));
+		tracker.onSubscribe(subscribeEvent("session-2", "sub-1", "/topic/chat.room." + ROOM_ID, MEMBER_ID));
+
+		tracker.onDisconnect(disconnectEvent("session-1"));
+
+		assertThat(tracker.isViewing(ROOM_ID, MEMBER_ID)).isTrue();
+	}
+
+	@Test
+	@DisplayName("memberId 없는 구독은 기록하지 않는다")
+	void subscribe_ignoresSessionWithoutMemberId() {
+		tracker.onSubscribe(subscribeEvent("session-1", "sub-1", "/topic/chat.room." + ROOM_ID, null));
+
+		assertThat(tracker.isViewing(ROOM_ID, MEMBER_ID)).isFalse();
+	}
+
+	private SessionSubscribeEvent subscribeEvent(String sessionId, String subId, String destination, Long memberId) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+		accessor.setSessionId(sessionId);
+		accessor.setSubscriptionId(subId);
+		accessor.setDestination(destination);
+		Map<String, Object> attributes = new HashMap<>();
+		if (memberId != null) {
+			attributes.put("memberId", memberId);
+		}
+		accessor.setSessionAttributes(attributes);
+		Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+		return new SessionSubscribeEvent(this, message);
+	}
+
+	private SessionUnsubscribeEvent unsubscribeEvent(String sessionId, String subId) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
+		accessor.setSessionId(sessionId);
+		accessor.setSubscriptionId(subId);
+		Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+		return new SessionUnsubscribeEvent(this, message);
+	}
+
+	private SessionDisconnectEvent disconnectEvent(String sessionId) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
+		accessor.setSessionId(sessionId);
+		Message<byte[]> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+		return new SessionDisconnectEvent(this, message, sessionId, null);
+	}
+}

--- a/chat-service/src/test/java/com/comatching/chat/domain/service/redis/RedisSubscriberTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/domain/service/redis/RedisSubscriberTest.java
@@ -1,0 +1,177 @@
+package com.comatching.chat.domain.service.redis;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.comatching.chat.domain.dto.ChatMessageResponse;
+import com.comatching.chat.domain.entity.ChatRoom;
+import com.comatching.chat.domain.enums.MessageType;
+import com.comatching.chat.domain.repository.ChatRoomRepository;
+import com.comatching.chat.domain.service.block.BlockService;
+import com.comatching.chat.domain.service.chat.ChatService;
+import com.comatching.chat.domain.service.presence.ChatRoomPresenceTracker;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@ExtendWith(MockitoExtension.class)
+class RedisSubscriberTest {
+
+	private static final String ROOM_ID = "room-1";
+	private static final Long INITIATOR_ID = 1L;
+	private static final Long TARGET_ID = 2L;
+
+	@Mock
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Mock
+	private SimpMessageSendingOperations messagingTemplate;
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private BlockService blockService;
+
+	@Mock
+	private ChatRoomPresenceTracker presenceTracker;
+
+	@Mock
+	private ChatService chatService;
+
+	@Mock
+	private RedisPublisher redisPublisher;
+
+	private RedisSubscriber redisSubscriber;
+
+	private final ObjectMapper objectMapper = createObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+		redisSubscriber = new RedisSubscriber(
+			objectMapper,
+			redisTemplate,
+			messagingTemplate,
+			chatRoomRepository,
+			blockService,
+			presenceTracker,
+			chatService,
+			redisPublisher
+		);
+		given(redisTemplate.getStringSerializer()).willReturn(new StringRedisSerializer());
+	}
+
+	@Test
+	@DisplayName("수신자가 방을 보고 있으면 브로드캐스트 후 서버가 대신 읽음 처리하고 READ를 발행한다")
+	void onMessage_autoReadsWhenReceiverIsViewingRoom() throws Exception {
+		ChatRoom room = chatRoom();
+		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		given(blockService.isBlocked(TARGET_ID, INITIATOR_ID)).willReturn(false);
+		given(presenceTracker.isViewing(ROOM_ID, TARGET_ID)).willReturn(true);
+
+		ChatMessageResponse readResponse = readResponse(TARGET_ID);
+		given(chatService.markAsRead(ROOM_ID, TARGET_ID)).willReturn(readResponse);
+
+		redisSubscriber.onMessage(redisMessage(talkResponse(INITIATOR_ID)), null);
+
+		then(messagingTemplate).should().convertAndSend(eq("/topic/chat.room." + ROOM_ID), any(ChatMessageResponse.class));
+		then(chatService).should().markAsRead(ROOM_ID, TARGET_ID);
+		then(redisPublisher).should().publish(any(ChannelTopic.class), eq(readResponse));
+	}
+
+	@Test
+	@DisplayName("수신자가 방을 보고 있지 않으면 읽음 처리하지 않는다")
+	void onMessage_skipsAutoReadWhenReceiverIsNotViewing() throws Exception {
+		ChatRoom room = chatRoom();
+		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		given(blockService.isBlocked(TARGET_ID, INITIATOR_ID)).willReturn(false);
+		given(presenceTracker.isViewing(ROOM_ID, TARGET_ID)).willReturn(false);
+
+		redisSubscriber.onMessage(redisMessage(talkResponse(INITIATOR_ID)), null);
+
+		then(messagingTemplate).should().convertAndSend(eq("/topic/chat.room." + ROOM_ID), any(ChatMessageResponse.class));
+		then(chatService).shouldHaveNoInteractions();
+		then(redisPublisher).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("READ 메시지에는 다시 읽음 처리하지 않는다 - 무한 발행을 막는다")
+	void onMessage_neverAutoReadsReadMessages() throws Exception {
+		ChatRoom room = chatRoom();
+		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		given(blockService.isBlocked(TARGET_ID, INITIATOR_ID)).willReturn(false);
+
+		redisSubscriber.onMessage(redisMessage(readResponse(INITIATOR_ID)), null);
+
+		then(messagingTemplate).should().convertAndSend(eq("/topic/chat.room." + ROOM_ID), any(ChatMessageResponse.class));
+		then(chatService).shouldHaveNoInteractions();
+		then(redisPublisher).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("수신자가 발신자를 차단했으면 전달도 읽음 처리도 하지 않는다")
+	void onMessage_skipsEverythingWhenBlocked() throws Exception {
+		ChatRoom room = chatRoom();
+		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		given(blockService.isBlocked(TARGET_ID, INITIATOR_ID)).willReturn(true);
+
+		redisSubscriber.onMessage(redisMessage(talkResponse(INITIATOR_ID)), null);
+
+		then(messagingTemplate).shouldHaveNoInteractions();
+		then(chatService).shouldHaveNoInteractions();
+		then(redisPublisher).shouldHaveNoInteractions();
+	}
+
+	private ChatRoom chatRoom() {
+		ChatRoom room = ChatRoom.builder()
+			.matchingId(100L)
+			.initiatorUserId(INITIATOR_ID)
+			.targetUserId(TARGET_ID)
+			.build();
+		ReflectionTestUtils.setField(room, "id", ROOM_ID);
+		return room;
+	}
+
+	private ChatMessageResponse talkResponse(Long senderId) {
+		return new ChatMessageResponse(
+			"message-1", ROOM_ID, senderId, "hello", MessageType.TALK,
+			LocalDateTime.of(2026, 8, 26, 10, 0), 1
+		);
+	}
+
+	private ChatMessageResponse readResponse(Long senderId) {
+		return new ChatMessageResponse(
+			null, ROOM_ID, senderId, null, MessageType.READ,
+			LocalDateTime.of(2026, 8, 26, 10, 1), 0
+		);
+	}
+
+	private DefaultMessage redisMessage(ChatMessageResponse response) throws Exception {
+		byte[] body = objectMapper.writeValueAsBytes(response);
+		return new DefaultMessage("chatroom".getBytes(StandardCharsets.UTF_8), body);
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return mapper;
+	}
+}

--- a/chat-service/src/test/java/com/comatching/chat/global/exception/ChatErrorHandlerTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/global/exception/ChatErrorHandlerTest.java
@@ -1,0 +1,37 @@
+package com.comatching.chat.global.exception;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import com.comatching.common.dto.response.ApiResponse;
+import com.comatching.common.exception.BusinessException;
+import com.comatching.common.exception.code.GeneralErrorCode;
+
+class ChatErrorHandlerTest {
+
+	private final ChatErrorHandler handler = new ChatErrorHandler();
+
+	@Test
+	@DisplayName("존재하지 않는 채팅방 예외를 에러 코드가 담긴 응답으로 바꿔 내려준다")
+	void handleBusinessException_carriesChatErrorCode() {
+		ApiResponse<Void> response =
+			handler.handleBusinessException(new BusinessException(ChatErrorCode.NOT_EXIST_CHATROOM));
+
+		assertThat(response.getCode()).isEqualTo(ChatErrorCode.NOT_EXIST_CHATROOM.getCode());
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+		assertThat(response.getMessage()).isEqualTo(ChatErrorCode.NOT_EXIST_CHATROOM.getMessage());
+	}
+
+	@Test
+	@DisplayName("남의 방에 보낸 경우도 같은 형태로 내려준다")
+	void handleBusinessException_carriesGeneralErrorCode() {
+		ApiResponse<Void> response =
+			handler.handleBusinessException(new BusinessException(GeneralErrorCode.FORBIDDEN));
+
+		assertThat(response.getCode()).isEqualTo(GeneralErrorCode.FORBIDDEN.getCode());
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+	}
+}

--- a/chat-service/src/test/java/com/comatching/chat/infra/controller/ChatControllerTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/infra/controller/ChatControllerTest.java
@@ -23,6 +23,7 @@ import com.comatching.chat.domain.enums.MessageType;
 import com.comatching.chat.domain.service.chat.ChatService;
 import com.comatching.chat.domain.service.chatroom.ChatRoomService;
 import com.comatching.chat.domain.service.redis.RedisPublisher;
+import com.comatching.common.dto.member.MemberInfo;
 import com.comatching.common.service.S3Service;
 
 @ExtendWith(MockitoExtension.class)
@@ -109,4 +110,29 @@ class ChatControllerTest {
 		then(redisPublisher).should().publish(any(ChannelTopic.class), eq(response));
 	}
 
+	@Test
+	@DisplayName("REST로도 읽음 처리할 수 있고 READ 이벤트가 상대에게 전파된다")
+	void markAsRead_viaRestPublishesReadEvent() {
+		// given - WebSocket 이 아직 안 붙었거나 끊긴 상태에서 방을 연 경우
+		ChatMessageResponse readResponse = new ChatMessageResponse(
+			null,
+			ROOM_ID,
+			MEMBER_ID,
+			null,
+			MessageType.READ,
+			LocalDateTime.of(2026, 8, 26, 10, 0),
+			0
+		);
+		MemberInfo memberInfo = new MemberInfo(MEMBER_ID, "user@test.com", "ROLE_USER");
+
+		given(chatService.markAsRead(ROOM_ID, MEMBER_ID)).willReturn(readResponse);
+		given(redisPublisher.publish(any(ChannelTopic.class), eq(readResponse))).willReturn(1L);
+
+		// when
+		chatController.markAsRead(ROOM_ID, memberInfo);
+
+		// then
+		then(chatService).should().markAsRead(ROOM_ID, MEMBER_ID);
+		then(redisPublisher).should().publish(any(ChannelTopic.class), eq(readResponse));
+	}
 }

--- a/chat-service/src/test/java/com/comatching/chat/infra/controller/ChatControllerTest.java
+++ b/chat-service/src/test/java/com/comatching/chat/infra/controller/ChatControllerTest.java
@@ -78,4 +78,35 @@ class ChatControllerTest {
 		inOrder.verify(chatService).processMessage(securedRequest);
 		inOrder.verify(redisPublisher).publish(any(ChannelTopic.class), eq(response));
 	}
+
+	@Test
+	@DisplayName("세션에 nickname이 없어도 메시지를 정상 처리하고 발행한다")
+	void sendMessage_worksWhenSessionHasNoNickname() {
+		// given - 프로필 완성 전에 발급된 토큰이면 게이트웨이가 X-Member-Nickname 을 안 보낸다
+		ChatMessageRequest request = new ChatMessageRequest(ROOM_ID, null, null, "hello", MessageType.TALK);
+		ChatMessageRequest securedRequest =
+			new ChatMessageRequest(ROOM_ID, MEMBER_ID, "", "hello", MessageType.TALK);
+		ChatMessageResponse response = new ChatMessageResponse(
+			"message-1",
+			ROOM_ID,
+			MEMBER_ID,
+			"hello",
+			MessageType.TALK,
+			LocalDateTime.of(2026, 5, 18, 0, 0),
+			1
+		);
+		SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
+		headerAccessor.setSessionAttributes(new HashMap<>(Map.of("memberId", MEMBER_ID)));
+
+		given(chatService.processMessage(securedRequest)).willReturn(response);
+		given(redisPublisher.publish(any(ChannelTopic.class), eq(response))).willReturn(1L);
+
+		// when
+		chatController.sendMessage(request, headerAccessor);
+
+		// then - 닉네임은 알림 미리보기용이라 없으면 빈 값으로 두고 전송은 살린다
+		then(chatService).should().processMessage(securedRequest);
+		then(redisPublisher).should().publish(any(ChannelTopic.class), eq(response));
+	}
+
 }

--- a/common-module/src/main/java/com/comatching/common/dto/chat/ChatRoomEnsureRequest.java
+++ b/common-module/src/main/java/com/comatching/common/dto/chat/ChatRoomEnsureRequest.java
@@ -1,0 +1,16 @@
+package com.comatching.common.dto.chat;
+
+/**
+ * 매칭에 대응하는 채팅방이 있는지 확인하고 없으면 만들어 달라는 요청.
+ *
+ * 방 생성은 원래 매칭 성공 Kafka 이벤트로만 일어났는데, 발행이 유실되면
+ * 그 매칭은 영구히 방이 없었다. 조회 시점에 생성까지 맡기면 유실분이
+ * 자동으로 복구된다. 생성에 필요한 참여자 정보는 매칭 이력이 알고 있으므로
+ * matching-service 가 채워 보낸다.
+ */
+public record ChatRoomEnsureRequest(
+	Long matchingId,
+	Long initiatorUserId,
+	Long targetUserId
+) {
+}

--- a/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingHistoryServiceImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/service/MatchingHistoryServiceImpl.java
@@ -3,7 +3,6 @@ package com.comatching.matching.domain.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -11,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.comatching.common.dto.chat.ChatRoomEnsureRequest;
 import com.comatching.common.dto.chat.ChatRoomReferenceResponse;
 import com.comatching.common.dto.matching.MatchingHistoryReferenceResponse;
 import com.comatching.common.dto.member.ProfileResponse;
@@ -76,18 +76,25 @@ public class MatchingHistoryServiceImpl implements MatchingHistoryService{
 		return PagingResponse.from(resultPage);
 	}
 
+	// 조회가 곧 보장이다. 방 생성은 매칭 성공 Kafka 이벤트에만 의존했는데,
+	// 발행이 유실되면 그 매칭은 영구히 방이 없었다. ensure 는 방이 없으면
+	// chat-service 가 그 자리에서 만들므로 유실분이 이력 조회 시점에 복구된다.
 	private Map<Long, String> getChatRoomIdMap(Page<MatchingHistory> histories) {
-		List<Long> matchingIds = histories.stream()
-			.map(MatchingHistory::getId)
-			.filter(Objects::nonNull)
+		List<ChatRoomEnsureRequest> ensureRequests = histories.stream()
+			.filter(history -> history.getId() != null)
+			.map(history -> new ChatRoomEnsureRequest(
+				history.getId(),
+				history.getMemberId(),
+				history.getPartnerId()
+			))
 			.distinct()
 			.toList();
 
-		if (matchingIds.isEmpty()) {
+		if (ensureRequests.isEmpty()) {
 			return Map.of();
 		}
 
-		List<ChatRoomReferenceResponse> chatRooms = chatRoomClient.getChatRoomReferences(matchingIds);
+		List<ChatRoomReferenceResponse> chatRooms = chatRoomClient.ensureChatRooms(ensureRequests);
 		if (chatRooms == null || chatRooms.isEmpty()) {
 			return Map.of();
 		}

--- a/matching-service/src/main/java/com/comatching/matching/infra/client/ChatRoomClient.java
+++ b/matching-service/src/main/java/com/comatching/matching/infra/client/ChatRoomClient.java
@@ -6,6 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.comatching.common.dto.chat.ChatRoomEnsureRequest;
 import com.comatching.common.dto.chat.ChatRoomReferenceResponse;
 
 @FeignClient(name = "chat-service", path = "/api/internal/chat/rooms", url = "${chat-service.url}")
@@ -13,4 +14,9 @@ public interface ChatRoomClient {
 
 	@PostMapping("/references")
 	List<ChatRoomReferenceResponse> getChatRoomReferences(@RequestBody List<Long> matchingIds);
+
+	// 방이 없는 매칭은 chat-service 가 그 자리에서 만든다. Kafka 발행이 유실된
+	// 매칭도 이력 조회 시점에 복구된다.
+	@PostMapping("/ensure")
+	List<ChatRoomReferenceResponse> ensureChatRooms(@RequestBody List<ChatRoomEnsureRequest> requests);
 }

--- a/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingHistoryServiceImplTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/service/MatchingHistoryServiceImplTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.comatching.common.dto.chat.ChatRoomEnsureRequest;
 import com.comatching.common.dto.chat.ChatRoomReferenceResponse;
 import com.comatching.common.dto.matching.MatchingHistoryReferenceResponse;
 import com.comatching.common.dto.member.ProfileResponse;
@@ -104,7 +105,7 @@ class MatchingHistoryServiceImplTest {
 		given(historyRepository.searchHistory(memberId, null, null, pageable))
 			.willReturn(new PageImpl<>(List.of(history), pageable, 1));
 		given(memberClient.getProfiles(List.of(partnerId))).willReturn(List.of(partnerProfile));
-		given(chatRoomClient.getChatRoomReferences(List.of(historyId)))
+		given(chatRoomClient.ensureChatRooms(List.of(new ChatRoomEnsureRequest(historyId, memberId, partnerId))))
 			.willReturn(List.of(new ChatRoomReferenceResponse(historyId, "room-100")));
 
 		// when
@@ -112,7 +113,7 @@ class MatchingHistoryServiceImplTest {
 			memberId, null, null, pageable, false
 		);
 
-		// then
+		// then - 조회가 곧 보장이다: 방이 없던 매칭도 이 호출로 만들어진 방 ID 를 받는다
 		assertThat(response.content()).hasSize(1);
 		assertThat(response.content().get(0).historyId()).isEqualTo(historyId);
 		assertThat(response.content().get(0).chatRoomId()).isEqualTo("room-100");


### PR DESCRIPTION
## 배경

실사용 테스트에서 두 증상이 보고됨: **매칭 직후 채팅이 바로 안 되는 경우**와 **읽음 표시("1")가 안 없어지는 경우**. 코드 추적으로 근본 원인 4건을 확정하고 각각 실패 테스트를 먼저 작성한 뒤 수정.

## 수정 내용

### 1. 죽은 에러 핸들러를 살리고 닉네임 NPE 를 막는다 (05af43a)
- `@MessageExceptionHandler(ChatException.class)` 는 발화 불가능했음 — `ChatException` 을 던지는 곳이 없고, 실제로 던져지는 `BusinessException` 과 상속 관계도 없음. 그래서 실패한 전송이 클라이언트에 아무 신호 없이 증발.
- 이제 `BusinessException` 을 잡아 REST 와 동일한 `ApiResponse` 형태로 `/user/queue/errors` 에 내려줌.
- 닉네임 클레임 없는 토큰(프로필 완성 전)으로 메시지를 보내면 NPE 로 전송이 죽던 것을 null 가드로 수정.

### 2. 방을 보고 있는 상대의 읽음을 서버가 대신 처리한다 (34ebc18)
- 읽음 갱신이 클라이언트의 방 입장 시 READ 한 번에만 의존 → 방을 켜둔 채 받은 메시지의 "1" 은 상대가 재입장할 때까지 절대 안 사라졌음.
- `ChatRoomPresenceTracker` 가 인스턴스별로 방 구독을 추적하고, 메시지 브로드캐스트 시점에 수신자가 그 방을 보고 있으면 서버가 읽음 처리 + READ 발행. 프론트 수정 없이 동작.
- WS 없는 상태를 위한 REST 폴백 `POST /api/chat/rooms/{roomId}/read` 추가.

### 3. 차단 상태의 첫 메시지에도 방을 활성화한다 (fb15227)
- 활성화(WAITING→ACTIVE)가 요약 갱신에 묶여 있어, 차단된 상대에게 보낸 첫 메시지는 방을 영구 WAITING 으로 남겼음 → 차단을 풀어도 target 목록에 방이 안 나타남.
- 활성화를 독립 원자 업데이트로 분리해 차단 경로에서도 수행. 요약·알림은 여전히 스킵.

### 4. 이력 조회 시 없는 채팅방을 그 자리에서 만든다 (2bb260c)
- 방 생성이 매칭 성공 Kafka 이벤트 하나에만 의존 → 매칭 직후엔 방이 아직 없고, 발행 유실 시 영구히 없음.
- 매칭 이력 조회가 chat-service 의 `/api/internal/chat/rooms/ensure` 를 타면서 없는 방을 그 자리에서 생성. 과거 유실분도 이력을 여는 순간 자동 복구. 동시 생성은 matchingId unique 인덱스 + 재조회로 안전.

## 검증

- 전 수정 TDD (RED 확인 후 구현): 신규 테스트 15개
- chat-service + matching-service 전체 스위트 161개 테스트 통과, 실패 0

## 프론트 후속 (선택, 권장)

1. `/user/queue/errors` 구독해 에러 토스트 표시
2. WS 연결 전에 방을 열었다면 `POST /api/chat/rooms/{roomId}/read` 호출

🤖 Generated with [Claude Code](https://claude.com/claude-code)