### PR TITLE
chore: CLAUDE.md 를 추적한다

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,3 +42,5 @@ jobs:
           # 액션은 claude_args 의 --allowedTools 가 이름을 대야만 인라인
           # 코멘트용 MCP 서버를 띄운다.
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # TODO(임시): 실패 원인을 보려고 켠다. 확인 후 되돌린다.
+          show_full_output: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,5 +42,3 @@ jobs:
           # 액션은 claude_args 의 --allowedTools 가 이름을 대야만 인라인
           # 코멘트용 MCP 서버를 띄운다.
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
-          # TODO(임시): 실패 원인을 보려고 켠다. 확인 후 되돌린다.
-          show_full_output: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,3 +42,6 @@ jobs:
           # 액션은 claude_args 의 --allowedTools 가 이름을 대야만 인라인
           # 코멘트용 MCP 서버를 띄운다.
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # TODO(임시): 액션이 SDK 출력을 가려서 실패 원인이 로그에 안 남는다.
+          # 원인 확인용으로만 켠다. 공개 저장소라 확인 즉시 되돌릴 것.
+          show_full_output: true

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,8 @@ bin/
 .claudeignore
 .claude
 .mcp.json
-CLAUDE.md
+# CLAUDE.md 는 추적한다. 개인 메모가 아니라 팀이 공유하는 프로젝트 규칙이고,
+# PR 리뷰 액션이 매 실행마다 읽어 docs/code-review-guidelines.md 로 간다.
 scripts
 .idea
 docker-compose.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# COMAtching Backend
+
+Spring 기반 MSA. 서비스는 gateway / user / matching / chat / item / notification 6개이며
+`common-module` 을 공유한다. 서비스 간 통신은 내부 REST(`/api/internal/**`)와 Kafka 이벤트.
+
+## 코드 리뷰
+
+리뷰 기준은 [docs/code-review-guidelines.md](docs/code-review-guidelines.md) 에 있다.
+코드 리뷰를 할 때는 그 문서를 먼저 읽고 거기 적힌 페르소나·언어·관점을 따른다.
+요약하면:
+
+- **리뷰 코멘트는 한국어로 작성한다.**
+- Spring MSA 실무 경험이 있는 Senior Back-end Engineer 관점으로 본다.
+- "동작한다"는 이유만으로 승인하지 않고, 미래의 변경에 얼마나 버티는지를 본다.
+- 문제를 지적할 때는 "왜 문제인지"와 "어떻게 개선할지"를 함께 쓴다.
+
+이 저장소 특유의 주의점:
+
+- **서비스 경계를 넘는 변경은 하위 호환성을 특히 주의해서 본다** —
+  `common-module` 의 DTO, 서비스 간 내부 API, Kafka 이벤트 스키마는
+  배포 순서가 어긋나는 순간 깨진다.
+- 운영 설정(`docker-compose.prod.yml`, `application-aws.yml`)은 EC2 단일 호스트에
+  6개 JVM 이 함께 뜨는 전제로 메모리 한도가 잡혀 있다. 한도를 건드리는 변경은
+  전체 예산과 함께 본다.


### PR DESCRIPTION
#74 에서 추가한 `CLAUDE.md` 가 `.gitignore` 에 걸려 커밋되지 않았다.

이 파일은 리뷰 기준(`docs/code-review-guidelines.md`)으로 가는 유일한 연결고리다. 없으면 Code Review 액션이 기준 없이 일반적인 리뷰만 한다 — 한국어 코멘트, Senior Back-end Engineer 페르소나, 서비스 경계 하위 호환성 주의 같은 게 전부 안 걸린다.

개인 메모가 아니라 팀이 공유하는 프로젝트 규칙이므로 추적 대상으로 돌린다.

이 PR 은 워크플로를 바꾸지 않으므로 Code Review 가 실제로 붙는지 확인하는 첫 대상이 된다.