### PR TITLE
ci: 디버그 출력을 끄고 리뷰에 턴 상한을 준다

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,7 @@ jobs:
           # 스킬 frontmatter 에 같은 도구가 적혀 있어도 이 줄은 남겨야 한다.
           # 액션은 claude_args 의 --allowedTools 가 이름을 대야만 인라인
           # 코멘트용 MCP 서버를 띄운다.
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
-          # TODO(임시): 액션이 SDK 출력을 가려서 실패 원인이 로그에 안 남는다.
-          # 원인 확인용으로만 켠다. 공개 저장소라 확인 즉시 되돌릴 것.
-          show_full_output: true
+          # --max-turns: 리뷰 한 건이 파일 읽기·검색·코멘트로 10~20턴을 쓴다.
+          # 상한이 낮으면 리뷰를 끝내기 전에 잘리고, 없으면 폭주할 때 멈출
+          # 지점이 없다. 실행 1회당 상한이지 하루 총량이 아니다.
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment" --max-turns 30'


### PR DESCRIPTION
## 변경

- `show_full_output: true` 제거 — 401 원인 파악용이었고, 공개 저장소라 오래 둘 수 없다
- `--max-turns 30` 추가

## 배경

토큰 재발급으로 `401 OAuth access token is invalid` 는 해결됐다. 그 다음 실행에서 드러난 문제는 스킬이 PR 상태 확인 서브에이전트를 백그라운드로 띄운 뒤 `I'll wait for the background agent's completion notification.` 로 턴을 끝내 버리는 것이다. CI 는 1회 실행이라 그 알림이 올 자리가 없어 리뷰가 시작도 못 하고 종료된다.

턴 상한을 넉넉히 줘서 한 실행 안에서 마치도록 한다. 실행 1회당 상한이지 하루 총량이 아니다.

## 이후

머지 후에도 조기 종료가 반복되면, `prompt` 를 스킬 호출 대신 단순 텍스트 지시로 바꾸는 것이 다음 후보다.