### PR TITLE
ci: 코드 리뷰가 조용히 증발하던 원인을 막는다

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,11 +37,30 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          # 스킬 frontmatter 에 같은 도구가 적혀 있어도 이 줄은 남겨야 한다.
-          # 액션은 claude_args 의 --allowedTools 가 이름을 대야만 인라인
-          # 코멘트용 MCP 서버를 띄운다.
+          # 두 번째 문단이 없으면 리뷰가 조용히 증발한다. 실제로 겪은 실패:
+          # 모델이 리뷰를 백그라운드 서브에이전트에 넘기고 "완료 알림을
+          # 기다리겠다"며 턴을 끝냈는데, Actions 헤드리스 실행에는 그 알림을
+          # 받을 루프가 없어 프로세스가 그대로 죽었다. 코멘트 0개로 초록불.
+          prompt: |
+            /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            리뷰는 이 턴 안에서 끝낸다. 서브에이전트를 백그라운드로 띄우고
+            완료 알림을 기다리지 마라 - Actions 에는 알림을 받을 루프가 없어
+            프로세스가 그대로 죽는다.
+          # allowedTools 는 화이트리스트다. 목록에 없는 도구는 permissionMode
+          # default + 비대화형 조합에서 그대로 거부된다.
+          # - Skill: 없으면 /code-review 스킬 본체가 로드되지 못한다. 모델은
+          #   거부당한 뒤 프롬프트에 실린 요약만 보고 즉흥적으로 움직인다.
+          # - Bash/Read/Glob/Grep: 스킬이 diff 를 읽고 코드를 뒤지는 데 쓴다.
+          # - Agent: 스킬이 리뷰어를 병렬로 나눌 때 쓴다. 백그라운드 전환은
+          #   위 프롬프트가 막는다.
+          # - mcp__github_inline_comment__*: 액션은 --allowedTools 가 이름을
+          #   대야만 인라인 코멘트용 MCP 서버를 띄운다. 스킬 frontmatter 에
+          #   같은 도구가 적혀 있어도 이 줄은 남겨야 한다.
           # --max-turns: 리뷰 한 건이 파일 읽기·검색·코멘트로 10~20턴을 쓴다.
           # 상한이 낮으면 리뷰를 끝내기 전에 잘리고, 없으면 폭주할 때 멈출
           # 지점이 없다. 실행 1회당 상한이지 하루 총량이 아니다.
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment" --max-turns 30'
+          claude_args: '--allowedTools "Skill,Bash,Read,Glob,Grep,Agent,mcp__github_inline_comment__create_inline_comment" --max-turns 30'
+          # 리뷰가 또 조용히 죽으면 로그에서 원인을 봐야 한다. 이 설정으로
+          # 몇 번 정상 동작하는 걸 확인하면 다시 지운다(기본값 false).
+          show_full_output: true


### PR DESCRIPTION
## 배경

리뷰 워크플로가 매 PR 마다 초록불인데 코멘트는 지금까지 **한 번도** 달린 적이 없다.
PR 75·76·77·78 전부 리뷰 0건.

## 무슨 일이 있었나

[실행 32925673612](https://github.com/COMAtching/Comatching5_BE/actions/runs/32925673612) 로그(디버그가 켜져 있던 유일한 실행)에 전문이 남아 있다:

```json
"num_turns": 5, "duration_ms": 15407, "permission_denials_count": 1
"permission_denials": [
  { "tool_name": "Skill",
    "tool_input": { "skill": "code-review:code-review", "args": "--comment .../pull/76" } }
]
"subagent_stats": { "spawned": 1, "started_in_background": 1, "completed": 0 }
"result": "I'll wait for the background agent's completion notification."
```

1. `allowedTools` 는 화이트리스트다. 목록에 `Skill` 이 없어서
   `/code-review:code-review` 스킬 본체가 로드되지 못하고 그대로 거부됐다.
2. 거부당한 모델은 프롬프트에 실린 요약만 보고 즉흥적으로 움직였다 —
   로그에 `"The skill instructions were already provided in the command
   context. I'll proceed directly..."` 가 남아 있다.
3. 그리고 리뷰를 **백그라운드 서브에이전트**에 넘긴 뒤 `ScheduleWakeup` 을
   걸고 "완료 알림을 기다리겠다"며 턴을 끝냈다. Actions 헤드리스 실행에는
   그 알림을 받을 루프가 없다. 프로세스가 그대로 죽고 서브에이전트는
   `completed: 0` 으로 사살됐다.
4. 버퍼에 코멘트 0개 → `No buffered inline comments` → 스텝 exit 0 → **초록불**.

리뷰 한 건이 15초 5턴에 끝난 게 이상하다고 봤어야 했다.

## 변경 내용

- **`allowedTools` 에 `Skill,Bash,Read,Glob,Grep,Agent` 추가.** `Skill` 이 직접
  원인이고, 나머지는 스킬이 diff 를 읽고 코드를 뒤지는 데 쓴다. 지금까지는
  서브에이전트 안에서만 우연히 돌아갔다.
- **프롬프트에 "이 턴 안에서 끝내라 / 백그라운드 서브에이전트 금지" 문단 추가.**
  1번을 고쳐도 모델이 다시 async 로 던지면 똑같이 조용히 죽는다.
- **`show_full_output: true` 를 한시적으로 켠다.** #77 에서 껐는데, 끄고 나니
  이번 실패의 원인을 볼 수가 없었다. 몇 번 정상 동작을 확인하면 다시 지운다.

## 이 PR 에는 리뷰가 안 붙는다 (정상)

액션은 워크플로 파일이 default 브랜치와 **바이트 단위로 동일할 때만** 실행된다.
PR 브랜치에서 리뷰 워크플로를 고쳐 시크릿을 빼가는 걸 막는 가드다:

```
Skipping action due to workflow validation: Workflow validation failed.
The workflow file must exist and have identical content to the version on
the repository's default branch.
```

따라서 이 수정은 자기 자신을 검증할 수 없다. main 에 머지된 다음 PR 78 에
푸시해서 실제로 리뷰가 달리는지 확인한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
