### PR TITLE
ci: 리뷰 디버그 출력을 다시 끈다

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,6 +61,3 @@ jobs:
           # 상한이 낮으면 리뷰를 끝내기 전에 잘리고, 없으면 폭주할 때 멈출
           # 지점이 없다. 실행 1회당 상한이지 하루 총량이 아니다.
           claude_args: '--allowedTools "Skill,Bash,Read,Glob,Grep,Agent,mcp__github_inline_comment__create_inline_comment" --max-turns 30'
-          # 리뷰가 또 조용히 죽으면 로그에서 원인을 봐야 한다. 이 설정으로
-          # 몇 번 정상 동작하는 걸 확인하면 다시 지운다(기본값 false).
-          show_full_output: true


### PR DESCRIPTION
## 배경

[#79](https://github.com/COMAtching/Comatching5_BE/pull/79) 에서 리뷰가 조용히 죽던 원인을 잡으려고 `show_full_output: true` 를 켰다.
원인을 잡았고 리뷰가 실제로 동작하는 것도 확인했으니 되돌린다.

## 확인된 동작

| PR | 실행 | 턴 | 결과 |
|---|---|---|---|
| [#80](https://github.com/COMAtching/Comatching5_BE/pull/80) | [32932921958](https://github.com/COMAtching/Comatching5_BE/actions/runs/32932921958) | 24 | `gradle.properties:19` 인라인 코멘트 게시 |
| [#78](https://github.com/COMAtching/Comatching5_BE/pull/78) | [32932880546](https://github.com/COMAtching/Comatching5_BE/actions/runs/32932880546) | 26 | 이슈 없음 요약 코멘트 게시 |

수정 전에는 5턴 15초에 끝나고 코멘트가 0건이었다.

## 변경 내용

`show_full_output` 한 줄 제거. 기본값 `false` 로 돌아간다.
`allowedTools` 와 프롬프트는 그대로 둔다 — 그게 실제 수정이다.

## 남은 과제 (이 PR 밖)

리뷰가 죽어도 스텝은 여전히 `exit 0` 을 낸다. 이번에 겪은 세 가지 실패
(권한 거부, 워크플로 검증 스킵, 백그라운드 에이전트 사망)가 전부 초록불이었다.
`permission_denials_count > 0` 이거나 `num_turns` 가 비정상적으로 낮으면
스텝을 실패시키는 가드가 따로 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
