### PR TITLE
feat: 참여자 수 조회에 10초 로컬 캐시를 건다

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 	// Kafka
 	implementation 'org.springframework.kafka:spring-kafka'
 
+	// Cache (참여자 수 등 읽기 빈도가 높고 실시간성이 낮은 조회의 로컬 캐시)
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/user-service/src/main/java/com/comatching/user/domain/member/service/MemberServiceImpl.java
+++ b/user-service/src/main/java/com/comatching/user/domain/member/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.comatching.user.domain.member.service;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -13,6 +14,7 @@ import com.comatching.common.exception.BusinessException;
 import com.comatching.user.domain.event.UserEventPublisher;
 import com.comatching.user.domain.member.entity.Member;
 import com.comatching.user.domain.member.repository.MemberRepository;
+import com.comatching.user.global.config.CacheConfig;
 import com.comatching.user.global.config.ProfileImageProperties;
 import com.comatching.user.global.exception.UserErrorCode;
 
@@ -86,6 +88,7 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
+	@Cacheable(CacheConfig.PARTICIPANT_COUNT)
 	public long getActiveUserCount() {
 		return memberRepository.countByRoleAndStatus(MemberRole.ROLE_USER, MemberStatus.ACTIVE);
 	}

--- a/user-service/src/main/java/com/comatching/user/global/config/CacheConfig.java
+++ b/user-service/src/main/java/com/comatching/user/global/config/CacheConfig.java
@@ -1,0 +1,32 @@
+package com.comatching.user.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	public static final String PARTICIPANT_COUNT = "participantCount";
+
+	/**
+	 * 참여자 수 COUNT 쿼리는 요청마다 ACTIVE 회원 수만큼 인덱스를 훑는다(회원 수에 비례).
+	 * 값 자체는 표시용이라 몇 초 늦어도 되므로 짧은 TTL 로컬 캐시로 DB 부하를 끊는다.
+	 * user-service 는 단일 인스턴스 전제라 인스턴스 간 정합성은 고려하지 않는다.
+	 */
+	@Bean
+	public CacheManager cacheManager() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager(PARTICIPANT_COUNT);
+		cacheManager.setCaffeine(Caffeine.newBuilder()
+			.expireAfterWrite(Duration.ofSeconds(10))
+			.maximumSize(100));
+		return cacheManager;
+	}
+}

--- a/user-service/src/test/java/com/comatching/user/domain/member/service/MemberServiceCacheTest.java
+++ b/user-service/src/test/java/com/comatching/user/domain/member/service/MemberServiceCacheTest.java
@@ -1,0 +1,74 @@
+package com.comatching.user.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.comatching.common.domain.enums.MemberRole;
+import com.comatching.common.domain.enums.MemberStatus;
+import com.comatching.user.domain.event.UserEventPublisher;
+import com.comatching.user.domain.member.repository.MemberRepository;
+import com.comatching.user.global.config.CacheConfig;
+import com.comatching.user.global.config.ProfileImageProperties;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MemberServiceCacheTest.TestConfig.class)
+@DisplayName("참여자 수 캐시 테스트")
+class MemberServiceCacheTest {
+
+	@Autowired
+	private MemberService memberService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("TTL 안에서는 반복 조회해도 COUNT 쿼리는 한 번만 나간다")
+	void shouldHitDatabaseOnlyOnceWithinTtl() {
+		// given
+		given(memberRepository.countByRoleAndStatus(MemberRole.ROLE_USER, MemberStatus.ACTIVE)).willReturn(50000L);
+
+		// when
+		long first = memberService.getActiveUserCount();
+		long second = memberService.getActiveUserCount();
+		long third = memberService.getActiveUserCount();
+
+		// then
+		assertThat(first).isEqualTo(50000L);
+		assertThat(second).isEqualTo(50000L);
+		assertThat(third).isEqualTo(50000L);
+		then(memberRepository).should(times(1)).countByRoleAndStatus(MemberRole.ROLE_USER, MemberStatus.ACTIVE);
+	}
+
+	@Configuration
+	@Import({CacheConfig.class, MemberServiceImpl.class})
+	static class TestConfig {
+
+		@Bean
+		MemberRepository memberRepository() {
+			return mock(MemberRepository.class);
+		}
+
+		@Bean
+		UserEventPublisher userEventPublisher() {
+			return mock(UserEventPublisher.class);
+		}
+
+		@Bean
+		ProfileImageProperties profileImageProperties() {
+			return mock(ProfileImageProperties.class);
+		}
+	}
+}


### PR DESCRIPTION
## 배경

운영 부하 측정(docs/perf-log.md 5회차)에서 `/api/auth/participants` 가 병목으로 확인됐다.

- COUNT 쿼리(`countByRoleAndStatus`)가 요청마다 ACTIVE 회원 수만큼 인덱스를 훑는다 — 운영 RDS EXPLAIN 기준 `idx_role_status` 커버링 인덱스를 타는데도(type=ref, Using index) rows=49,616
- 10만 시드에서 처리량 상한 60 RPS, 제공 부하를 올려도 처리량은 59/59/60 으로 평탄, p50 은 839→1678→3351ms 선형 증가
- 시드 1만→10만 (10배) 에 상한 300→60 RPS (1/5) — 데이터 양에 비례해 무너지는 전형적 O(N) COUNT

## 변경

- `getActiveUserCount()` 에 `@Cacheable` — Caffeine `expireAfterWrite` **10초** 로컬 캐시
- `CacheConfig`: `@EnableCaching` + CaffeineCacheManager (신규)
- 의존성: `spring-boot-starter-cache` + `caffeine` (버전은 Boot BOM 관리)

## 설계 판단

- **로컬 캐시 (Redis 아님)**: user-service 는 단일 인스턴스 전제. Redis 를 거치면 네트워크 홉·직렬화만 추가된다.
- **무효화 없음**: 참여자 수는 표시용이라 최대 10초 지연은 무해. 가입/탈퇴 이벤트 연동 무효화는 복잡도 대비 이득이 없다.
- **메모리**: 캐시 엔트리는 long 1개 (maximumSize 100) — EC2 메모리 예산에 영향 없음.

## 검증

- `MemberServiceCacheTest`: 스프링 컨텍스트에서 3회 연속 호출 시 COUNT 쿼리가 1번만 나가는지 검증 — 통과
- 머지·배포 후 동일 절차(10만 시드 유지 중)로 재측정하여 60 RPS 상한 해소 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)