### PR TITLE
ci: 배포 후 미사용 이미지를 전부 지운다

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -172,11 +172,13 @@ jobs:
             # --no-build: EC2 에서 소스를 빌드하지 않는다. 이미지는 이미 만들어져 있다.
             docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --no-build
 
-            # 배포마다 서비스 6개의 이미지가 새로 쌓인다. prune -f 는 태그
-            # 없는 것만 지우는데, 옛 커밋 SHA 이미지는 태그가 붙어 있어 그대로
-            # 남는다. -a 로 "컨테이너가 쓰지 않는 것"까지 대상에 넣되, 72시간은
-            # 남겨 최근 버전으로 되돌릴 여지를 둔다.
-            docker image prune -af --filter "until=72h"
+            # 배포마다 서비스 6개의 이미지(~3GB 세트)가 새로 쌓인다. prune -f 는
+            # 태그 없는 것만 지우는데, 옛 커밋 SHA 이미지는 태그가 붙어 있어
+            # 그대로 남는다. -a 로 "컨테이너가 쓰지 않는 것"을 전부 지운다.
+            # 예전엔 until=72h 로 롤백 여지를 뒀지만, 머지가 잦은 날 세대가
+            # 쌓여 29GB 디스크가 가득 차 배포 자체가 죽었다(2026-08-26).
+            # 롤백은 GHCR 에 남아 있는 이미지를 다시 pull 하면 된다.
+            docker image prune -af
 
       - name: 상태 확인
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
## 배경

2026-08-26 디스크 풀 사고. 배포마다 커밋 SHA 태그 이미지 6개(~3GB 세트)를 pull 하는데, 정리 명령이 `docker image prune -af --filter "until=72h"` 라서 72시간 안 된 이미지는 안 지워진다. 머지가 잦은 날에는 세대가 그대로 쌓인다.

실측: 이미지 81개 / overlay2 24GB / 디스크 99% (잔여 297MB) → #82 배포가 pull 도중 `no space left on device` 로 실패.

## 변경

`until=72h` 필터 제거 — 배포 후 실행 중인 컨테이너가 쓰는 이미지만 남기고 전부 삭제.

## 판단 근거

- 필터는 "최근 버전으로 되돌릴 여지"용이었지만, 롤백은 GHCR 에 남아 있는 이미지를 `IMAGE_TAG=<옛 SHA>` 로 다시 pull 하면 된다. 로컬 보관이 필요 없다.
- prune 은 `up -d` 다음에 돌므로 새로 뜬 세트는 항상 보존된다.
- 이 PR 머지로 도는 배포가 실패했던 #82(참여자 수 캐시)까지 함께 배포한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)