### PR TITLE
ci: 자동 리뷰는 diff만, cross-service 분석은 @claude 수동으로

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,6 +47,13 @@ jobs:
             리뷰는 이 턴 안에서 끝낸다. 서브에이전트를 백그라운드로 띄우고
             완료 알림을 기다리지 마라 - Actions 에는 알림을 받을 루프가 없어
             프로세스가 그대로 죽는다.
+
+            이 자동 리뷰는 diff 에 나온 코드만 본다. common-module 등
+            diff 밖의 다른 서비스로 건너가 소비 코드를 찾아 읽는 하위 호환성
+            분석은 하지 마라 - 시간이 몇 배로 늘어난다. diff 가
+            common-module 의 DTO, 서비스 간 내부 API, Kafka 이벤트 스키마를
+            건드린다면, 그 분석 대신 코멘트에 "cross-service 영향 확인이
+            필요합니다 - `@claude` 로 수동 리뷰를 요청하세요" 한 줄만 남겨라.
           # allowedTools 는 화이트리스트다. 목록에 없는 도구는 permissionMode
           # default + 비대화형 조합에서 그대로 거부된다.
           # - Skill: 없으면 /code-review 스킬 본체가 로드되지 못한다. 모델은

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,6 +3,12 @@
 #
 #   @claude ChatRoomPresenceTracker 가 동시성 안전한지 봐줘
 #   @claude 이 테스트 깨지는 원인 찾아줘
+#
+# common-module/내부 API/Kafka 스키마처럼 서비스 경계를 넘는 변경의 하위
+# 호환성 분석은 여기서 한다. claude-code-review.yml 은 diff 만 보는 얕은
+# 리뷰라 그 분석을 하지 않고, 대신 이 워크플로를 부르라는 코멘트만 남긴다.
+#
+#   @claude 이 PR 의 common-module 변경이 다른 서비스에 미치는 영향 봐줘
 name: Claude Code
 
 on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ Spring 기반 MSA. 서비스는 gateway / user / matching / chat / item / notifi
 - **서비스 경계를 넘는 변경은 하위 호환성을 특히 주의해서 본다** —
   `common-module` 의 DTO, 서비스 간 내부 API, Kafka 이벤트 스키마는
   배포 순서가 어긋나는 순간 깨진다.
+  - **단, PR 자동 리뷰(`claude-code-review.yml`)는 diff 에 나온 코드만 보고
+    끝낸다.** 다른 서비스로 건너가 소비 코드를 찾아 읽는 하위 호환성
+    분석은 턴·시간을 크게 늘린다 — diff 가 `common-module`/내부 API/Kafka
+    스키마를 건드리면 자동 리뷰는 코멘트에 "cross-service 영향 확인 필요"
+    한 줄만 남기고, 실제 분석은 PR 코멘트에 `@claude` 로 명시적으로
+    요청했을 때(`claude.yml`)만 수행한다.
 - 운영 설정(`docker-compose.prod.yml`, `application-aws.yml`)은 EC2 단일 호스트에
   6개 JVM 이 함께 뜨는 전제로 메모리 한도가 잡혀 있다. 한도를 건드리는 변경은
   전체 예산과 함께 본다.


### PR DESCRIPTION
## Summary
- PR #85(common-module 변경)의 자동 리뷰가 9분 넘게 걸린 원인 확인: diff는 403줄로 크지 않았지만, CLAUDE.md의 "서비스 경계를 넘는 변경은 하위 호환성을 특히 주의해서 본다" 지침 때문에 diff 밖 다른 서비스의 소비 코드까지 찾아 읽은 것으로 보임.
- 자동 PR 리뷰(`claude-code-review.yml`)는 diff에 나온 코드만 보도록 프롬프트로 범위를 좁힘. common-module/내부 API/Kafka 스키마 변경이 있으면 실제 분석 대신 "`@claude`로 수동 리뷰 요청" 코멘트만 남기게 함.
- cross-service 하위 호환성 분석은 `claude.yml`(`@claude` 수동 호출)의 역할로 문서화.
- `allowedTools`는 그대로 둠 — #79에서 도구를 뺐다가 리뷰 코멘트가 통째로 증발한 사고가 있어서, 속도 문제는 도구 제한이 아니라 프롬프트 범위 조정으로만 해결.

## Test plan
- [ ] 이 PR 자체는 diff가 workflow/문서뿐이라 common-module을 건드리지 않음 — 자동 리뷰가 평소처럼 빠르게 끝나는지 확인
- [ ] 다음 common-module 변경 PR에서 자동 리뷰가 "cross-service 영향 확인 필요" 코멘트만 남기고 빠르게 끝나는지 확인
- [ ] 해당 PR에 `@claude 이 PR의 common-module 변경이 다른 서비스에 미치는 영향 봐줘`로 수동 호출했을 때 실제 cross-service 분석이 나오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)