### PR TITLE
fix: findBestCandidate 에 readOnly 트랜잭션 — 매칭 상한 30 RPS 의 원인 수정

### DIFF
--- a/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/repository/candidate/MatchingCandidateRepositoryImpl.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 
@@ -84,7 +85,17 @@ public class MatchingCandidateRepositoryImpl implements MatchingCandidateReposit
 
     private final EntityManager em;
 
+    /**
+     * readOnly 트랜잭션이 성능 수정이다 (회차 8).
+     * 이 메서드는 네이티브 쿼리라 트랜잭션 없이 돌면 Hibernate 의
+     * release-after-transaction 이 발동할 트랜잭션이 없고, OSIV 세션이
+     * 닫히는 요청 끝까지 커넥션을 쥔다 — 상대 프로필 Feign 호출까지 포함해서.
+     * 실측: 커넥션 점유 113~337ms (SQL 자체는 ~25ms), 풀 10개가
+     * 10 ÷ 0.33s ≈ 30 RPS 에서 처리량 상한이 됐다.
+     * 트랜잭션 경계를 쿼리에 딱 맞추면 점유가 SQL 시간으로 줄어든다.
+     */
     @Override
+    @Transactional(readOnly = true)
     public Optional<MatchingCandidate> findBestCandidate(MatchingCandidateSearchCondition condition) {
         Optional<MatchingCandidate> found = queryBestCandidate(condition);
 


### PR DESCRIPTION
## 무엇을

`MatchingCandidateRepositoryImpl.findBestCandidate` 에 `@Transactional(readOnly = true)` 한 줄을 붙인다.

## 왜 (회차 8, docs/perf-log.md)

S2 매칭 부하테스트에서 처리량이 **~30 RPS 에 상한**이 걸렸다. CPU 는 여유였고, Prometheus 실측:

- Hikari active **10/10** (풀 상한) + pending **38**
- 커넥션 1회 점유 평균 **113ms(한가할 때) ~ 337ms(부하 시)** — 순수 SQL 은 ~25ms

원인: 이 메서드는 트랜잭션 없는 네이티브 쿼리다. Hibernate 의 release-after-transaction 이 발동할 트랜잭션이 없으니, OSIV(부트 기본 `open-in-view: true`) 세션이 닫히는 **요청 끝까지 커넥션을 쥔다** — 상대 프로필 Feign 호출(부하 시 수백 ms)까지 포함해서.

풀 10개 ÷ 점유 0.33초 ≈ **30 RPS — 관측된 상한과 정확히 일치.**

## 어떻게

트랜잭션 경계를 쿼리에 딱 맞춘다. 쿼리가 끝나면 커넥션이 즉시 풀로 돌아가고, 이후 Feign·Kafka 구간은 커넥션 없이 돈다. 엔티티는 OSIV 영속성 컨텍스트에 남아 이후 lazy 접근도 기존과 동일하게 동작한다 (동작 변화 없음, 점유 시간만 축소).

기대: 점유 330ms → ~30ms — 풀이 정하는 상한 30 → 수백 RPS. 다음 벽은 호스트 CPU(25 RPS 계단에서 ~81%).

`open-in-view: false` 전면 적용은 컨트롤러의 lazy 접근 전수 확인이 필요해서 별도 작업으로 남긴다.

## 검증

- `:matching-service:compileJava` 통과
- 머지 → 배포 후 S2 재측정(회차 9)으로 상한 이동 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)