### PR TITLE
perf: 매칭 표본 5,000 → 2,000 — RDS CPU 병목 완화

### DIFF
--- a/matching-service/src/main/java/com/comatching/matching/domain/component/MatchingProcessor.java
+++ b/matching-service/src/main/java/com/comatching/matching/domain/component/MatchingProcessor.java
@@ -52,7 +52,14 @@ import java.util.concurrent.ThreadLocalRandom;
 public class MatchingProcessor {
 
     private static final int MAX_ALLOWED_AGE = 27;
-    private static final int SAMPLE_SIZE = 5_000;
+    /**
+     * 5,000 → 2,000 (회차 10). 상한 29 RPS 의 병목이 RDS CPU(db.t3.micro 2 vCPU,
+     * 6개 서비스 공유)로 확정됐고, 후보 쿼리의 temp table·정렬 대상이 표본
+     * 크기에 비례한다. 회차 3 분포표 기준 80점 이상 확보율은 5,000=99.9% →
+     * 2,000=94.2% — 사용자는 점수를 보지 못하고 동점 그룹 무작위 선택 구조라
+     * 체감 차이가 없는 반면 RDS CPU 는 표본에 비례해 돌아온다.
+     */
+    private static final int SAMPLE_SIZE = 2_000;
 
     private final MatchingCandidateRepository candidateRepository;
     private final MatchingHistoryRepository historyRepository;

--- a/matching-service/src/test/java/com/comatching/matching/domain/component/MatchingProcessorTest.java
+++ b/matching-service/src/test/java/com/comatching/matching/domain/component/MatchingProcessorTest.java
@@ -342,7 +342,7 @@ class MatchingProcessorTest {
 		void passesSamplingParameters() {
 			MatchingCandidateSearchCondition condition = capture(request().build());
 
-			assertThat(condition.sampleSize()).isEqualTo(5_000);
+			assertThat(condition.sampleSize()).isEqualTo(2_000);
 			assertThat(condition.randomStart())
 				.isBetween(0, MatchingCandidate.RANDOM_KEY_START_BOUND - 1);
 		}


### PR DESCRIPTION
## 무엇을

`MatchingProcessor.SAMPLE_SIZE` 5,000 → 2,000.

## 왜 (회차 10, docs/perf-log.md)

매칭 상한 29 RPS 의 병목이 **RDS CPU**(db.t3.micro 2 vCPU, 6개 서비스 공유)로 확정됐다 — 스레드 덤프(요청 스레드 78/106 이 풀 대기, 커넥션 보유자는 전원 쿼리 실행 중) + 동시성 실측(표본 쿼리 단독 129ms → 10동시 1,084ms).

후보 쿼리의 temp table·정렬 대상이 표본 크기에 비례한다. 표본을 60% 줄이면 매칭 1건당 RDS CPU 가 그만큼 돌아온다.

## 트레이드오프 (회차 3 분포표)

| 표본 | 80점 이상 확보 | 85점 이상 | 90점(진짜 최고) |
|---|---|---|---|
| 5,000 | 99.9% | 85.0% | 33.0% |
| **2,000** | **94.2%** | 53.2% | 14.8% |

사용자는 점수를 보지 못하고 애초에 동점 그룹에서 무작위로 받는 구조라 체감 차이 없음. 오히려 후보 쏠림이 더 완화된다.

## 검증

- 컴파일 통과. 머지 → 배포 후 같은 조건 재측정(회차 11)으로 상한 이동 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)